### PR TITLE
topic similarity

### DIFF
--- a/src/dataprep/helpers/functions.py
+++ b/src/dataprep/helpers/functions.py
@@ -1,5 +1,6 @@
 import time 
 import warnings 
+import itertools
 
 def print_elapsed_time(start_time):
     print(f"Time elapsed: {(time.time()-start_time)/60} minutes \n", flush = True)
@@ -118,3 +119,12 @@ def yield_gazetteer(results, iteration_id):
             for canon_id, score in matches:
                 # XXX for graduates the column order of links needs to be adjusted!
                 yield (messy_id, canon_id, score, iteration_id)            
+
+
+def enumerated_arguments(*args, limit=None):
+    """From a generator *args, yield a tuple (i, *args[i]) for i in range(len(args)). 
+    limit: int or None
+        If not None, only return the first `limit` tuples.    
+    """
+    for i, k in enumerate(itertools.islice(*args, limit)):
+        yield ((i,) + tuple([j for j in k]))

--- a/src/dataprep/main/link/read_topic_similarity.py
+++ b/src/dataprep/main/link/read_topic_similarity.py
@@ -41,11 +41,11 @@ file_map = {
     "inst": {
         "fn_full": "sim_to_institutions_full.csv",
         "tbl": "graduates_similarity_to_institutions",
-        "schema": """(AuthorId
-            , AffiliationId
-            , period
-            , similarity_faculty_overall
-            , similarity_closest_collaborator)""",
+        "schema": """(AuthorId INT 
+            , AffiliationId INT 
+            , period TEXT
+            , similarity_faculty_overall REAL
+            , similarity_closest_collaborator REAL)""",
         "idx": [
             """CREATE UNIQUE INDEX idx_gsi_AuthorAffilPeriod
                 ON graduates_similarity_to_institutions (AuthorId, AffiliationId, period)"""
@@ -62,11 +62,11 @@ file_map = {
     "closest_collaborator_ids": {
         "fn_full": "sim_closest_collaborator_full.csv",
         "tbl": "graduates_closest_collaborators",
-        "schema": """(AuthorId
-            , AffiliationId
-            , CoAuthorId
-            , period
-            , similarity)""",
+        "schema": """(AuthorId INT 
+            , AffiliationId INT
+            , CoAuthorId INT
+            , period TEXT
+            , similarity REAL)""",
         "idx": [
             """CREATE UNIQUE INDEX idx_gcc_AuthorAffilCoAuthorPeriod 
                 ON graduates_closest_collaborators(AuthorId ASC, AffiliationId ASC, CoAuthorId ASC, period)"""
@@ -95,7 +95,7 @@ for id, params in file_map.items():
 
 
 
-shutil.rmtree(args.read_dir) 
+# shutil.rmtree(args.read_dir) 
 
 
 # ## Run ANALYZE, finish

--- a/src/dataprep/main/link/read_topic_similarity.py
+++ b/src/dataprep/main/link/read_topic_similarity.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""
+Script read_topic_similarity.py
+Read the files, outputted in topic_similarity.py, into the database with the following steps:
+    - delete existing table if necessary
+    - using subprocess, collect files into one
+    - using subprocess and sqlite command line, read into db
+    - put indexes on table
+"""
+
+
+import sqlite3 as sqlite
+import time 
+import argparse
+import subprocess
+import time 
+import os 
+import shutil
+import logging 
+
+from helpers.functions import analyze_db
+from helpers.variables import db_file 
+
+logging.basicConfig(level=logging.INFO)
+
+parser = argparse.ArgumentParser(description = 'Inputs for read_topic_similarity')
+parser.add_argument("--read_dir", dest="read_dir", default = "similarities_temp/")
+
+args = parser.parse_args()
+
+
+start_time = time.time()
+
+con = sqlite.connect(database = db_file, isolation_level= None)
+
+
+logging.info("Combining files into one")
+file_map = {
+    "inst": {
+        "fn_full": "sim_to_institutions_full.csv",
+        "tbl": "graduates_similarity_to_institutions",
+        "schema": """(AuthorId
+            , AffiliationId
+            , period
+            , similarity_faculty_overall
+            , similarity_closest_collaborator)""",
+        "idx": [
+            """CREATE UNIQUE INDEX idx_gsi_AuthorAffilPeriod
+                ON graduates_similarity_to_institutions (AuthorId, AffiliationId, period)"""
+        ]
+        },
+    "own": {
+        "fn_full": "sim_own_full.csv",
+        "tbl": "graduates_similarity_to_self",
+        "schema": "(AuthorId INTEGER, similarity REAL)",
+        "idx": [
+            "CREATE UNIQUE INDEX idx_gss_Author ON graduates_similarity_to_self (AuthorId ASC)"
+        ]
+    },
+    "closest_collaborator_ids": {
+        "fn_full": "sim_closest_collaborator_full.csv",
+        "tbl": "graduates_closest_collaborators",
+        "schema": """(AuthorId
+            , AffiliationId
+            , CoAuthorId
+            , period
+            , similarity)""",
+        "idx": [
+            """CREATE UNIQUE INDEX idx_gcc_AuthorAffilCoAuthorPeriod 
+                ON graduates_closest_collaborators(AuthorId ASC, AffiliationId ASC, CoAuthorId ASC, period)"""
+            , """CREATE INDEX idx_gcc_AuthorCoAuthor 
+                ON graduates_closest_collaborators (AuthorId ASC, CoAuthorId ASC)"""
+            ]
+    } 
+}
+
+
+for id, params in file_map.items():
+    subprocess.run(f"tail -n +2 -q {args.read_dir}/{id}-part-*.csv >> {params['fn_full']}", shell=True)
+    with con as c:
+        c.execute(f"DROP TABLE IF EXISTS {params['tbl']}")
+        c.execute(f"CREATE TABLE {params['tbl']} {params['schema']}")
+    subprocess.run(
+        ["sqlite3", db_file,
+        ".mode csv",
+        f".import {params['fn_full']} {params['tbl']}"]
+    )
+    os.remove(params['fn_full'])
+    with con as c:
+        for idx in params["idx"]:
+            c.execute(idx)
+
+
+
+
+shutil.rmtree(args.read_dir) 
+
+
+# ## Run ANALYZE, finish
+analyze_db(con)
+
+con.close()
+
+end_time = time.time()
+
+print(f"Done in {(end_time - start_time)/60} minutes.")
+

--- a/src/dataprep/main/link/similarity_helpers.py
+++ b/src/dataprep/main/link/similarity_helpers.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import numpy as np 
+
+def cosine_similarity_on_df(df):
+    "Final step for calculating cosine similarity in a dataframe"
+    df["sim"] = (
+        df["AB"] / (np.sqrt(df["AA"] + 1e-7) * np.sqrt(df["BB"] + 1e-7))
+    ) # 1e-7: small constant to avoid dividing by 0
+    return df 
+
+def fill_nas(df, varlist, fill=0):
+    for v in varlist:
+        df[v] = np.where(df[v].isna(), fill, df[v])
+    return df 
+
+
+def split_year_pre_post(df, ref_year):
+    df["period"] = np.where(df["Year"] <= ref_year, "pre_phd", "post_phd")
+    return df 
+    
+def unique(sequence):
+    "Helper to keep unique elements in a list. " # https://stackoverflow.com/questions/9792664/converting-a-list-to-a-set-changes-element-order
+    seen = set()
+    return [x for x in sequence if not (x in seen or seen.add(x))]
+

--- a/src/dataprep/main/link/topic_similarity.py
+++ b/src/dataprep/main/link/topic_similarity.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Script topic_similarity.py
+Calculate topic similarity for linked graduates
+    - between their topics pre and post phd
+    - between potential employers
+        - to faculty average 
+        - to most similar faculty member
+The first reported field0 in the proquest data is used 
+as the relevant field of study for each graduate: this means 
+that for economics graduates, only other economists/economics "departments"
+are considered for computing the topic similarities.
+"""
+
+import sqlite3 as sqlite
+import time 
+import pandas as pd
+from helpers.variables import db_file, insert_questionmark_doctypes, keep_doctypes
+from helpers.functions import enumerated_arguments
+import pdb 
+import argparse
+import logging 
+import os 
+import sys 
+import multiprocessing as mp 
+import itertools 
+from concurrent.futures import ProcessPoolExecutor
+import warnings
+
+import main.link.topic_similarity_functions as tsf
+
+
+logging.basicConfig(level=logging.INFO)
+
+# ## Arguments
+parser = argparse.ArgumentParser(description = 'Inputs for topic_similarity')
+parser.add_argument("--ncores", 
+                    dest="n_cores", 
+                    default=int(mp.cpu_count() / 2),
+                    type=int, 
+                    help="Number of cores to use. Defaults to half of available CPUs.")
+parser.add_argument("--top_n_authors", 
+                    type=int,
+                    default=200,
+                    help="Keep as many authors for each institution to search for most similar faculty member.") 
+parser.add_argument("--window_size",
+                    type=int,
+                    default=5,
+                    help="Calculate topics based on as many papers before or after graduation year.")
+parser.add_argument("--write_dir", 
+                    dest="write_dir", 
+                    default="similarities_temp/")
+parser.add_argument("--limit",
+                    type=int,
+                    default=None,
+                    help="Limit number of field-degree year combinations to process. For quick testing.")
+args = parser.parse_args()
+
+
+def get_similarities(data):
+    """Calculate similarities between graduates from `degree_year` in `field`
+    to their potential employers (on average/to closest potential collaborator), 
+    and to themselves (pre/post graduation).
+    The results are saved as csv for further processing.
+
+    Parameters:
+    ----------
+    chunk_id: int
+        Identifier of the chunk
+    dbfile: str
+        location of database to query
+    write_dir: str
+        path to store processed results
+    degree_year: int
+        degree year to process
+    field: str
+        field of study level 0 to process
+    keep_top_n_authors: int
+        keep as many authors, ordered by number of publications,
+        when calculating the most simlar author at a given institution-field.
+    """
+    chunk_id, dbfile, write_dir, degree_year, field, keep_top_n_authors = data 
+
+    con = sqlite.connect(database = "file:" + dbfile + "?mode=ro", 
+                         isolation_level=None, 
+                         uri=True) # read-only connection 
+
+    logging.debug(f"{chunk_id=}, {degree_year=}, {field=}")
+    sql_queries = tsf.QueryBuilder(
+        degree_year_to_query=degree_year,
+        window_size=args.window_size,
+        field_to_query=field,
+        qmarks_doctypes=insert_questionmark_doctypes,
+        keep_doctypes=keep_doctypes
+    )
+
+    with con as c:
+        d_affiliations = pd.read_sql(
+            con=c, 
+            sql=sql_queries.query_affiliations()
+        )
+
+    ## stuff for main function 
+    logging.info("getting student data")
+    student_topics, d_graduates = tsf.get_student_data(
+        con=con, 
+        queries=sql_queries
+        )
+
+    d_similarity_prepost = tsf.compute_similarity(
+        df_A=student_topics.loc[
+            student_topics["period"] == "pre_phd", 
+            ["AuthorId", "FieldOfStudyId", "Score"]
+            ],
+        df_B=student_topics.loc[
+            student_topics["period"] == "post_phd",
+            ["AuthorId", "FieldOfStudyId", "Score"]
+        ],
+        unit_A=["AuthorId"],
+        unit_B=["AuthorId"],
+        groupvars=["AuthorId"],
+        fill_A_units=True
+    )
+
+    # ### Topic similarity between graduate and average faculty 
+    logging.info("similarity to faculty")
+
+    d_similarity_to_faculty = tsf.similarity_to_faculty(
+        d_affiliations=d_affiliations,
+        d_graduates=d_graduates,
+        student_topics=student_topics,
+        queries=sql_queries,
+        con=con
+    )
+
+
+    # ### Topic similarity between graduate and most similar faculty member 
+    logging.info("similarity to closest collaborator")
+    d_most_similar_collaborator, highest_similarity_by_institution = tsf.similarity_to_closest_collaborator(
+        con=con,
+        queries=sql_queries,
+        student_topics=student_topics,
+        d_affiliations=d_affiliations,
+        d_graduates=d_graduates,
+        top_n_authors=keep_top_n_authors
+    )
+
+    # ## Make one df for similarity to institutions
+    logging.info("making d_similarity_institutions")
+
+    idx_vars = ["AuthorId", "AffiliationId", "period", "Field0"]
+    d_similarity_to_institutions = (
+        d_similarity_to_faculty
+            .set_index(idx_vars)
+            .rename(columns={"sim": "similarity_faculty_overall"})
+            .join(highest_similarity_by_institution
+                    .set_index(idx_vars)
+                    .rename(columns={"sim": "similarity_closest_collaborator"}))
+            .reset_index()
+            .drop(columns=["Field0"])
+    )
+
+    write_dict = {
+        "own": d_similarity_prepost,
+        "inst": d_similarity_to_institutions,
+        "closest_collaborator_ids": d_most_similar_collaborator.drop(columns=['Field0'])
+    }
+
+    for name, df in write_dict.items():
+        df.to_csv(f"{write_dir}/{name}-part-{chunk_id}.csv", index=False)
+
+    logging.debug("Done with one chunk.")
+
+    con.close()
+
+
+
+def main():
+    if args.n_cores > mp.cpu_count():
+        print("Specified too many cpu cores.")
+        print(f"Using max available, which is {mp.cpu_count()}.")
+        args.n_cores = mp.cpu_count()
+
+    if os.path.isdir(args.write_dir):
+        sys.exit("You specified an existing directory.")
+
+    # ## Setup
+    start_time = time.time()    
+    
+    os.mkdir(args.write_dir)
+
+    # ## Prepare inputs for mp 
+    con = sqlite.connect(database = "file:" + db_file + "?mode=ro", 
+                        isolation_level=None, 
+                        uri=True) # read-only connection 
+
+    # we need all years, all fields level 0 
+    q_fields = """
+        SELECT FieldOfStudyId
+        FROM FieldsOfStudy
+        WHERE Level = 0
+    """
+
+    q_years = """
+        SELECT DISTINCT degree_year 
+        FROM pq_authors
+        INNER JOIN (
+            SELECT goid
+            FROM current_links
+        ) USING(goid)
+    """
+
+    fields = con.execute(q_fields).fetchall()
+    fields = [f[0] for f in fields]
+    years = con.execute(q_years).fetchall()
+    years = [y[0] for y in years]
+    con.close()
+
+    inputs = itertools.product(
+        [db_file], [args.write_dir], years, fields, [args.top_n_authors]
+        )
+
+    enumerated_inputs = enumerated_arguments(inputs, limit=args.limit)
+    ctx = mp.get_context("forkserver")
+    logging.info("Running queries")
+    with ProcessPoolExecutor(max_workers=args.n_cores, mp_context=ctx) as executor:
+        result = executor.map(get_similarities, enumerated_inputs, chunksize=1)
+
+    print("--queries finished.")
+
+    # check number of created files is as expected
+    n_expected = len(years) * len(fields)
+    files_created = os.listdir(args.write_dir)
+    if n_expected * 3 != len(files_created):
+        warnings.warn("The number of files created does not match the expected number. Check the output carefully.")
+
+    # ## Finish
+    end_time = time.time()
+    print(f"Done in {(end_time - start_time)/60} minutes.")
+
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/dataprep/main/link/topic_similarity.py
+++ b/src/dataprep/main/link/topic_similarity.py
@@ -56,8 +56,8 @@ parser.add_argument("--limit",
                     type=int,
                     default=None,
                     help="Limit number of field-degree year combinations to process. For quick testing.")
+parser.add_argument('--no-parallel', action=argparse.BooleanOptionalAction, dest="noparallel")
 args = parser.parse_args()
-
 
 def get_similarities(data):
     """Calculate similarities between graduates from `degree_year` in `field`
@@ -225,8 +225,12 @@ def main():
     enumerated_inputs = enumerated_arguments(inputs, limit=args.limit)
     ctx = mp.get_context("forkserver")
     logging.info("Running queries")
-    with ProcessPoolExecutor(max_workers=args.n_cores, mp_context=ctx) as executor:
-        result = executor.map(get_similarities, enumerated_inputs, chunksize=1)
+    if args.noparallel:
+        inputs = (0, db_file, args.write_dir, 2005, 162324750, args.top_n_authors)
+        get_similarities(inputs)
+    else:
+        with ProcessPoolExecutor(max_workers=args.n_cores, mp_context=ctx) as executor:
+            result = executor.map(get_similarities, enumerated_inputs, chunksize=1)
 
     print("--queries finished.")
 

--- a/src/dataprep/main/link/topic_similarity_functions.py
+++ b/src/dataprep/main/link/topic_similarity_functions.py
@@ -1,0 +1,702 @@
+import pandas as pd 
+import numpy as np 
+
+import main.link.similarity_helpers as sim_helpers
+import logging 
+
+
+class QueryBuilder():
+    "Construct sql queries for similarity computations"
+    def __init__(
+        self, 
+        degree_year_to_query,
+        window_size, 
+        field_to_query,
+        qmarks_doctypes,
+        keep_doctypes):
+
+        self.degree_year_to_query = degree_year_to_query
+        self.window_size = window_size
+        self.field_to_query = field_to_query
+        self.qmarks_doctypes = qmarks_doctypes 
+        self.keep_doctypes = keep_doctypes
+        self.year_restriction = f"""
+            WHERE Year <= {degree_year_to_query} + {window_size}
+            AND Year >= {degree_year_to_query} - {window_size}
+        """
+    
+    def query_affiliations(self):
+        q = """
+            SELECT AffiliationId
+            FROM affiliations a
+            INNER JOIN (
+                SELECT from_id, unitid 
+                FROM links_to_cng
+                WHERE from_dataset = 'mag'
+            ) b
+            ON a.AffiliationId = b.from_id
+        """
+        return q 
+    
+    def query_affiliation_size(self, affiliation_ids_to_query):
+        affiliation_ids_to_query = ", ".join(str(i) for i in affiliation_ids_to_query)
+        q = f"""
+            SELECT AffiliationId, AuthorCount
+            FROM affiliation_outcomes
+            WHERE AffiliationId IN ({affiliation_ids_to_query})
+                AND Field0 = {self.field_to_query}
+                AND Year = {self.degree_year_to_query}
+        """
+        return q 
+            
+    def query_graduates(self):
+        q = f"""
+            SELECT goid, AuthorId, degree_year, Field0
+            FROM current_links
+            INNER JOIN (
+                SELECT goid, degree_year
+                FROM pq_authors
+                WHERE degree_year = {self.degree_year_to_query}
+            ) USING(goid)
+            INNER JOIN (
+                SELECT goid, mag_field0 AS Field0
+                FROM pq_fields_mag
+                WHERE position = 0
+                    AND field0 = {self.field_to_query}
+            ) USING(goid)
+        """
+        return q 
+    
+    def query_topics_dissertation(self):
+        q = f"""
+            SELECT AuthorId, FieldOfStudyId, score AS Score
+            FROM pq_magfos 
+            INNER JOIN (
+                {self.query_graduates()}
+            ) USING(goid)
+        """
+        return q 
+
+    def query_topics_postphd(self):
+        q = f"""
+            SELECT PaperId
+                , AuthorId
+                , goid
+                , FieldOfStudyId
+                , Score
+            FROM PaperAuthorUnique a 
+            INNER JOIN (
+                SELECT PaperId, Year
+                FROM Papers
+                WHERE DocType IN ({self.qmarks_doctypes})
+            ) b 
+            USING(PaperId)
+            INNER JOIN (
+                {self.query_graduates()}
+            ) c
+            USING(AuthorId)
+            INNER JOIN (
+                SELECT PaperId, FieldOfStudyId, Score
+                FROM PaperFieldsOfStudy
+            ) d
+            USING(PaperId)
+            WHERE Year <= degree_year + {self.window_size}
+                AND Year > degree_year
+                AND Score > 0
+            """
+        return q
+
+    def query_collaborators(self, affiliation_ids_to_query=None):
+        q = f"""
+            SELECT *
+            FROM AuthorAffiliation 
+            INNER JOIN (
+                {self.query_affiliations()}
+            ) USING(AffiliationId)
+            INNER JOIN (
+                SELECT AuthorId
+                FROM author_fields
+                WHERE FieldClass = 'main'
+                    AND FieldOfStudyId = {self.field_to_query}
+            ) c
+            USING(AuthorId)
+            {self.year_restriction}
+        """
+        if affiliation_ids_to_query is not None:
+            assert isinstance(affiliation_ids_to_query, list)
+            affiliation_ids_to_query = ", ".join(str(i) for i in affiliation_ids_to_query)
+            q = f"{q} AND AffiliationId IN ({affiliation_ids_to_query})"
+        
+        return q 
+    
+    def query_author_papers(self, affiliation_ids_to_query=None):
+        "Extract papers of relevant authors."
+        keep_authors = f"""
+            SELECT AuthorId 
+            FROM (
+                {self.query_collaborators(affiliation_ids_to_query=affiliation_ids_to_query)}
+            )
+        """
+        q = f"""
+            SELECT PaperId, AuthorId, Year 
+            FROM PaperAuthorUnique 
+            INNER JOIN (
+                SELECT PaperId, Year 
+                FROM Papers 
+                WHERE DocType IN ({self.qmarks_doctypes})
+            ) USING(PaperId)
+            {self.year_restriction} 
+                AND AuthorId IN (
+                    {keep_authors}
+                )
+        """
+        return q 
+    
+
+    def query_collaborators_topics(self, author_ids_to_query):
+        author_ids_to_query = ", ".join(str(i) for i in author_ids_to_query)
+        q = f"""
+            SELECT AuthorId
+            , FieldOfStudyId
+            , Year
+            , Score / PaperCount AS Score
+            , Field0
+            , PaperCount
+        FROM author_fields_detailed a
+        INNER JOIN (
+            SELECT AuthorId, FieldOfStudyId AS Field0
+            FROM author_fields
+            WHERE FieldClass = 'main'
+        ) c
+        USING(AuthorId)
+        {self.year_restriction}
+        AND AuthorId IN ({author_ids_to_query})
+        """
+        return q 
+    
+    def query_affiliation_topics(self):
+
+        year_restriction = f"""
+            WHERE a.Year <= {self.degree_year_to_query} + {self.window_size}
+            AND a.Year >= {self.degree_year_to_query} - {self.window_size}
+        """
+        q = f"""
+            SELECT a.AffiliationId
+                , a.Field0
+                , a.Year
+                , a.FieldOfStudyId
+                , a.Score / c.PaperCount AS Score
+            FROM affiliation_fields a
+            INNER JOIN (
+                {self.query_affiliations()}
+            ) b USING(AffiliationId)
+            INNER JOIN (
+                SELECT AffiliationId
+                    , Field0
+                    , Year
+                    , PaperCount
+                FROM affiliation_outcomes
+            ) c
+            ON a.AffiliationId = c.AffiliationId
+                AND a.Year = c.Year
+                AND a.Field0 = c.Field0
+                {year_restriction}
+                AND a.Field0 = {self.field_to_query}
+        """
+        return q 
+
+
+## Support functions 
+
+def compute_similarity(df_A, df_B, unit_A, unit_B, groupvars, fill_A_units = False, debug=False):
+    """Compute similarity between records in df_A and in df_B.
+    unit_A and unit_B refer to column names defining the units of observation.
+    groupvars define other grouping variables common in df_A and df_B.
+    """
+    df_A = df_A.rename(columns={"Score": "A"})
+    df_B = df_B.rename(columns={"Score": "B"})
+
+    if debug:
+        breakpoint()
+
+    d_AA = (df_A 
+        .assign(AA=lambda x: x.A**2)
+        .groupby(sim_helpers.unique(unit_A + groupvars))
+        .agg({"AA": np.sum})
+    )
+    d_BB = (df_B 
+        .assign(BB=lambda x: x.B**2)
+        .groupby(sim_helpers.unique(unit_B + groupvars))
+        .agg({"BB": np.sum})
+        )
+    d_AB = (df_B
+        .set_index(sim_helpers.unique(groupvars + ["FieldOfStudyId"]))
+        .join(df_A
+                .set_index(sim_helpers.unique(groupvars + ["FieldOfStudyId"])), 
+                how="inner")
+        .reset_index()
+    )
+    d_AB = (d_AB
+        .assign(AB=lambda x: x.A * x.B)
+        .groupby(sim_helpers.unique(unit_A + unit_B + groupvars))
+        .agg({"AB": np.sum})
+        .reset_index()
+        .set_index(list(d_AA.index.names))
+        .join(d_AA)
+        .reset_index()
+        .set_index(list(d_BB.index.names))
+        .join(d_BB)
+        .reset_index()
+    )
+    d_AB = sim_helpers.cosine_similarity_on_df(d_AB)
+
+    if fill_A_units:
+        # fill all units in df_A with similarity of 0
+        required_ids = pd.DataFrame(d_AA.reset_index()[unit_A].squeeze().unique())
+        required_ids.columns = unit_A
+        d_AB = (required_ids
+            .set_index(unit_A)
+            .join(d_AB.set_index(unit_A))
+            .reset_index()
+        )
+        d_AB = sim_helpers.fill_nas(d_AB, ["sim"])
+
+    outvars = unit_A + unit_B + groupvars + ["sim"]
+    return d_AB.loc[:, sim_helpers.unique(outvars)]
+
+
+def complete_to_reference(
+    df_in, 
+    df_ref, 
+    idx_cols,
+    add_cols_to_complete,
+    ignore_column="Field0",
+    fill_value=0
+    ):
+    """Complete a dataframe df_in relative to a reference dataframe df_ref.
+    
+    Parameters:
+    ----------
+    df_in, df_ref: dataframes
+    idx_cols: index columns to join the two dfs by. 
+    add_cols_to_complete: additional columns over which to complete the dataframe
+    ignore_column: ignore this column for the "complete" operation
+    fill_value: fill value passed as `fill_value` to `pd.MultiIndex.from_product()`
+    """
+    cols_to_complete = idx_cols + add_cols_to_complete
+    flds = df_ref[ignore_column].unique()
+    ls_out = []
+    for fld in flds:
+        # join 
+        d_full = (
+            df_ref
+                .loc[df_ref[ignore_column]==fld, idx_cols]
+                .set_index(idx_cols)
+                .join(df_in
+                        .drop(columns=[ignore_column])
+                        .set_index(idx_cols))
+                .reset_index()
+        )
+        # "complete"
+        d_full = d_full.set_index(cols_to_complete)
+        mux = pd.MultiIndex.from_product(
+            [lvl for lvl in d_full.index.levels],
+            names=cols_to_complete
+        )
+        d_full = d_full.reindex(mux, fill_value=fill_value).reset_index()
+        d_full[ignore_column] = fld
+        ls_out.append(d_full)
+
+
+    return pd.concat(ls_out)
+
+
+## Main functions here 
+
+def get_student_data(con, queries):
+    """Prepare main data at student level
+    
+    Parameters:
+    ----------
+    con: sqlite connection
+    queries: QueryBuilder instance
+    
+    """
+    with con as c:
+        topics_dissertation = pd.read_sql(
+            con=c, 
+            sql=queries.query_topics_dissertation()
+        )
+        topics_postphd = pd.read_sql(
+            con=c, 
+            sql=queries.query_topics_postphd(),
+            params=queries.keep_doctypes
+        )
+        # general tables for later reference
+        d_graduates = pd.read_sql(
+            con=c, 
+            sql=queries.query_graduates()
+        )
+
+    n_papers_postphd = (topics_postphd
+                        .groupby(["AuthorId"])
+                        .agg({"PaperId": pd.Series.nunique})
+                        .rename(columns={"PaperId": "PaperCount"})
+                        )
+
+    topics_postphd = (topics_postphd
+                        .groupby(["AuthorId", "FieldOfStudyId"])
+                        .agg({"Score": np.sum})
+                        .reset_index(["FieldOfStudyId"])
+                        .join(n_papers_postphd)
+                        .reset_index()
+                    )
+    topics_postphd["Score"] = topics_postphd["Score"] / topics_postphd["PaperCount"]
+    topics_postphd = topics_postphd.drop(columns="PaperCount")
+
+    # create pre/post df for similarity calculations below 
+    topics_postphd["period"] = "post_phd"
+    topics_dissertation["period"] = "pre_phd"
+    student_topics = pd.concat(
+        [topics_postphd, topics_dissertation]
+    )
+    student_topics = (student_topics
+        .set_index(["AuthorId"])
+        .join(d_graduates
+                .loc[:, ["AuthorId", "Field0"]]
+                .set_index(["AuthorId"])
+                )
+        .reset_index()
+    )
+    return (student_topics, d_graduates)
+
+def make_student_affiliation_table(d_affiliations, d_graduates):
+    """Make reference table with all student-affiliation combinations 
+    which needs to be filled with data at the end
+
+    Parameters:
+    ----------
+    d_affiliations: dataframe with hiring AffiliationIds 
+    d_graduates: dataframe with goid, AuthorId, degree year and Field0
+
+    """
+    d_affiliations["key"] = 0 
+    d_field0 = pd.DataFrame(d_graduates["Field0"].unique())
+    d_field0.columns = ["Field0"]
+    d_field0["key"] = 0
+    d_affiliations_fields = (d_affiliations
+        .set_index(["key"])
+        .join(d_field0.set_index(["key"]), 
+                on="key", 
+                how="outer")
+        .reset_index()
+        )
+    d_graduates["key"] = 0 
+    d_out = (d_affiliations_fields
+        .set_index(["Field0", "key"])
+        .join(d_graduates
+                .loc[:, ["AuthorId", "Field0", "key"]]
+                .set_index(["Field0", "key"]),
+                on=["Field0", "key"],
+                how="outer"
+                )
+        .reset_index()
+        .drop(columns=["key"])
+        )
+
+    n_grads_affils = d_out.groupby(["AffiliationId", "AuthorId"]).ngroups
+    assert n_grads_affils == d_out.shape[0], "AuthorId-AffiliationId not unique"
+
+    return d_out
+
+def similarity_to_faculty(
+        d_affiliations, 
+        d_graduates,
+        student_topics,
+        queries,
+        con
+    ):
+    """Calculate similarity between student topics and overall faculty topics.
+
+    Parameters:
+    -----------
+    d_affiliations: dataframe with hiring AffiliationIds 
+    d_graduates: dataframe with goid, AuthorId, degree year and Field0
+    student_topics: dataframe with scores by AuthorId, FieldOfStudyId, period and Field0
+    queries: QueryBuilder instance
+    con: sqlite connection
+    """
+
+    # Get affiliation topics 
+    with con as c:
+        df_fields = pd.read_sql(con=c, sql=queries.query_affiliation_topics())
+    
+    df_fields = sim_helpers.split_year_pre_post(df=df_fields, ref_year=queries.degree_year_to_query)
+
+    affiliation_topics = (df_fields
+        .groupby(["AffiliationId", "Field0", "FieldOfStudyId", "period"])
+        .agg({"Score": np.sum})
+        .reset_index()
+        )
+
+    # calculate similarity 
+    d_sim = compute_similarity(
+        df_A=student_topics, 
+        df_B=affiliation_topics,
+        unit_A=["AuthorId"],
+        unit_B=["AffiliationId"], 
+        groupvars=["period", "Field0"])
+
+    # "reference" table 
+    d_graduates_affiliations = make_student_affiliation_table(
+        d_affiliations=d_affiliations,
+        d_graduates=d_graduates
+    )
+    d_sim = complete_to_reference(
+        df_in=d_sim, 
+        df_ref=d_graduates_affiliations,
+        idx_cols=["AuthorId", "AffiliationId"], 
+        add_cols_to_complete=["period"]
+    )
+
+    # NOTE: should Field0 be dropped? it is based on the student's field of study id.. 
+        # but it is good to keep in mind *based on what data* the statistics were calculated
+    return d_sim
+
+
+def similarity_to_closest_collaborator(
+        con,
+        queries,
+        student_topics,
+        d_affiliations,
+        d_graduates,
+        top_n_authors=200,
+        max_nrow_input_similarity=10_000_000
+    ):
+    """Calcuate highest similarity between students among potential coauthors, for all potential
+    destination institutions.
+
+    Parameters:
+    -----------
+    con: sqlite connection
+    quries: QueryBuilder instance
+    student_topics: dataframe with scores by AuthorId, FieldOfStudyId, period, Field0
+    d_affiliations, d_graduates: dataframes with affiliations and graduates
+    top_n_authors: For each institution, only consider top_n_authors by number of papers
+        in a given time period (defined in queries.year_restriction.)
+    max_nrow_input_similarity: Maximum number of rows to be processed by compute_similarity.
+        Chunks of affiliation ids are processed sequentially to reduce
+        memory of each operation.
+    """
+
+    # 1. Get data 
+    # logging.debug(f"querying db for affiliations.")
+    with con as c:
+        collaborators_affiliations = pd.read_sql(
+            con=c, 
+            sql=queries.query_collaborators())
+        collaborators_papers = pd.read_sql(
+            con=c,
+            sql=queries.query_author_papers(),
+            params=queries.keep_doctypes
+        )
+
+    collaborators_affiliations = sim_helpers.split_year_pre_post(
+        df=collaborators_affiliations, 
+        ref_year=queries.degree_year_to_query
+    )
+    collaborators_papers = sim_helpers.split_year_pre_post(
+        df=collaborators_papers, 
+        ref_year=queries.degree_year_to_query
+    )
+
+    # 2. a. Find first and last affiliation relative to the PhD year of the graduates
+    collaborators_affiliations["diff"] = np.abs(
+        collaborators_affiliations["Year"] - queries.degree_year_to_query
+    )
+    collaborators_affiliations["min_diff"] = (collaborators_affiliations
+        .groupby(["AuthorId", "period"])["diff"]
+        .transform("min")
+    )
+    collaborators_affiliations = collaborators_affiliations.loc[
+        collaborators_affiliations["min_diff"] == collaborators_affiliations["diff"],
+        ["AuthorId", "AffiliationId", "period"]
+    ]
+    collaborators_affiliations = (collaborators_affiliations
+        .drop_duplicates()
+        )
+
+    # 2.b. Find top n authors by papercount for each affiliation
+    collaborators_papercount = (
+        collaborators_papers
+            .groupby(["AuthorId", "period"])
+            .agg({"PaperId": pd.Series.nunique})
+            .rename(columns={"PaperId": "PaperCount"})
+    )
+
+    logging.debug(f"top_n_authors is {top_n_authors}")
+    d_top_collaborators = (
+        collaborators_affiliations
+            .set_index(list(collaborators_papercount.index.names))
+            .join(collaborators_papercount)
+            .reset_index()
+            .set_index(["AuthorId"])
+            .groupby(["period", "AffiliationId"])
+            ["PaperCount"]
+            .nlargest(top_n_authors)
+            .reset_index()
+            .rename(columns={"AuthorId": "CoAuthorId"})
+            .drop(columns=["PaperCount"])
+    )
+
+    collaborators_to_query = list(d_top_collaborators["CoAuthorId"].unique())
+
+    # 3. query the topics of these authors. 
+        # NOTE: already conditional on field_to_query b/c of restriction to AuthorIds
+    # logging.debug("querying db for topics of collaborators")
+    with con as c:
+        topics_collaborators = pd.read_sql(
+            con=c, 
+            sql=queries.query_collaborators_topics(author_ids_to_query=collaborators_to_query)
+        )
+
+    # 4. aggregate pre/post, by field 
+    topics_collaborators = sim_helpers.split_year_pre_post(
+        df=topics_collaborators, 
+        ref_year=queries.degree_year_to_query
+    )
+    topics_collaborators = (topics_collaborators
+        .groupby(["AuthorId", "Field0", "period", "FieldOfStudyId"])
+        .agg({"Score": np.sum})
+        .reset_index()
+        .rename(columns={"AuthorId": "CoAuthorId"})
+        )
+
+    topics_collaborators_affiliations = (d_top_collaborators
+        .set_index(["CoAuthorId", "period"])
+        .join(topics_collaborators
+            .set_index(["CoAuthorId", "period"]),
+            how="left")
+        .reset_index()
+        )
+    
+    size_graduates = student_topics.shape[0] 
+    topics_collaborators_affiliations = make_itergroups(
+        df=topics_collaborators_affiliations,
+        groupcol=["AffiliationId"],
+        max_size=int(max_nrow_input_similarity / size_graduates),
+        new_colname="itergroup"
+    )
+
+    compare_groups = (
+        f"""Have {topics_collaborators_affiliations['itergroup'].nunique()} itergroups """
+        f"""and {topics_collaborators_affiliations['AffiliationId'].nunique()} affiliation ids"""
+    )
+    logging.debug(compare_groups)
+
+    logging.debug(f"computing similarity between graduates and collaborators")
+    d_sim = []
+    for n, g in topics_collaborators_affiliations.groupby("itergroup"):
+        dtemp = compute_similarity(
+                df_A=student_topics,
+                df_B=g,
+                unit_A=["AuthorId"],
+                unit_B=["CoAuthorId", "AffiliationId"],
+                groupvars=["Field0", "period"]
+                )
+        d_sim.append(dtemp)
+    
+    d_sim = pd.concat(d_sim)
+        
+    
+    # 5. calculate individual similarity, keep most similar 
+    # logging.debug("max similarity between graduates and institutions")
+    d_sim["max_sim"] = (
+        d_sim
+            .groupby(["AuthorId", "Field0", "period", "AffiliationId"])["sim"]
+            .transform("max")
+    )
+
+    d_most_similar_collaborator = (
+        d_sim.loc[
+            d_sim["sim"] == d_sim["max_sim"], 
+            ["AuthorId", "AffiliationId", "CoAuthorId", "period", "Field0", "sim"]
+        ]
+    ) # can have multiple at same institution if the similarity is the same 
+
+    # 6. Separate most similar collaborator IDs from max distance 
+    # logging.debug("separate most similar collaborator and affiliations")
+    idx_vars = ["AuthorId", "Field0", "AffiliationId", "period"]
+    sim_most_similar_collaborator_by_affiliation = (
+        d_most_similar_collaborator
+            .loc[:, idx_vars + ["sim"]]
+            .drop_duplicates()
+    )
+    d_graduates_affiliations = make_student_affiliation_table(
+        d_affiliations=d_affiliations,
+        d_graduates=d_graduates
+    )
+    sim_most_similar_collaborator_by_affiliation = complete_to_reference(
+        df_in=sim_most_similar_collaborator_by_affiliation,
+        df_ref=d_graduates_affiliations,
+        idx_cols=["AuthorId", "AffiliationId"], 
+        add_cols_to_complete=["period"]
+    )
+
+    return d_most_similar_collaborator, sim_most_similar_collaborator_by_affiliation
+
+
+def make_itergroups(df, groupcol, max_size, new_colname):
+    """From a df, make a new column to iterate over, where all rows from a group
+    are contained in the same itergroup. 
+    Each itergroup should roughly have the same number of rows.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        The dataframe on which to generate the column.
+    groupcol: str
+        The column in `df` whose rows should all be in the same new itergroup.
+    max_size: int
+        Maximum size of the newly created itergroup.
+    new_colname: str
+        Name of the new column.
+    """
+    agg = df.groupby(groupcol).size().reset_index(name="counts")
+
+    newgroups = make_groups(df_to_iter(agg), max_size)
+
+    newgroups = pd.DataFrame(newgroups.items())
+    newgroups.columns = groupcol + [new_colname]
+
+    out = (
+        df.set_index(groupcol)
+            .join(newgroups
+                    .set_index(groupcol))
+            .reset_index()
+    )
+    return out 
+
+
+def make_groups(items, size_max):
+    "Make groups of equal size of size_max from items with (identifier, size)"
+    count = 0 
+    outdict = {}
+    n_groups = 0
+    for item in items:
+        count += item[1]
+        outdict[item[0]] = n_groups
+        if count >= size_max:
+            count = 0
+            n_groups += 1
+    
+    return outdict
+
+
+def df_to_iter(df):
+    "yield itertuples without the index column."
+    for i in df.itertuples():
+        yield list(i)[1:]
+
+
+

--- a/src/dataprep/main/prep_mag/authors_fields_detailed.py
+++ b/src/dataprep/main/prep_mag/authors_fields_detailed.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Script authors_fields_detailed.py
+
+Generate table:
+- authors_fields_detailed: score and number of papers per authorid, year, fieldofstudyid
+- eventually, this could be combined with prep_authors.py, and the script that creates author_output 
+    (since we are calculating number of papers again here)
+"""
+
+import sqlite3 as sqlite
+import warnings
+import time 
+import argparse
+import logging 
+from helpers.functions import print_elapsed_time, analyze_db
+from helpers.variables import db_file, insert_questionmark_doctypes, keep_doctypes
+
+logging.basicConfig(level=logging.INFO)
+
+# ## Arguments
+parser = argparse.ArgumentParser()
+args = parser.parse_args()
+
+# ## Variables; connect to db
+start_time = time.time()
+print(f"Start time: {start_time} \n")
+interactive = False
+
+con = sqlite.connect(database = db_file, isolation_level= None)
+
+query_limit = ""
+if interactive:
+    query_limit = "LIMIT 1000"
+
+base_query = f"""
+    SELECT PaperId
+        , AuthorId
+        , FieldOfStudyId
+        , Score
+        , Year
+    FROM PaperAuthorUnique
+    INNER JOIN (
+        SELECT AuthorId 
+        FROM author_sample
+    ) USING(AuthorId)
+    INNER JOIN (
+        SELECT PaperId
+            , FieldOfStudyId
+            , Score
+        FROM PaperFieldsOfStudy
+    ) USING(PaperId)
+    INNER JOIN (
+        SELECT PaperId, Year 
+        FROM Papers
+        WHERE DocType IN ({insert_questionmark_doctypes})
+    ) USING(PaperId)
+    {query_limit}
+"""
+
+
+with con as c:
+    logging.debug("Running base query")
+    c.execute(f"""
+        CREATE TEMP TABLE author_paper_field_temp AS 
+        {base_query}
+        """, 
+        keep_doctypes
+    )
+
+    logging.debug("Creating temp tables")
+    c.execute("""
+    CREATE TEMP TABLE author_field_temp AS
+    SELECT AuthorId
+        , FieldOfStudyId
+        , Year 
+        , SUM(Score) AS Score 
+    FROM author_paper_field_temp
+    GROUP BY AuthorId, FieldOfStudyId, Year 
+    """)
+    
+    c.execute("CREATE UNIQUE INDEX idx_tmp1 ON author_field_temp (AuthorId ASC, Year ASC, FieldOfStudyId)")
+
+    c.execute("""
+    CREATE TEMP TABLE author_paper_count AS
+    SELECT AuthorId
+        , Year
+        , COUNT(DISTINCT PaperId) AS PaperCount
+    FROM author_paper_field_temp
+    GROUP BY AuthorId, Year
+    """)
+
+    c.execute("CREATE UNIQUE INDEX idx_tmp2 ON author_paper_count (AuthorId ASC, Year ASC)")
+
+    logging.debug("Making final table")
+    c.execute("DROP TABLE IF EXISTS author_fields_detailed")
+
+    c.execute("""
+    CREATE TABLE author_fields_detailed AS 
+    SELECT * 
+    FROM author_field_temp
+    INNER JOIN author_paper_count
+    USING(AuthorId, Year)
+    """)
+
+    indexes = [
+        "UNIQUE INDEX idx_afd_autfieldyr ON author_fields_detailed (AuthorId ASC, FieldOfStudyId, Year ASC)",
+        "INDEX idx_adf_field ON author_fields_detailed (FieldOfStudyId ASC)",
+        "INDEX idx_adf_yr ON author_fields_detailed (YEAR ASC)"
+    ]
+
+    for idx in indexes:
+        c.execute(f"CREATE {idx}")
+
+
+# ## Run ANALYZE, finish
+with con as c:
+    analyze_db(c)
+
+
+con.close()
+
+end_time = time.time()
+
+print(f"Done in {(end_time - start_time)/60} minutes.")
+
+
+

--- a/src/dataprep/main/prep_mag/prep_quantiles_papercites.py
+++ b/src/dataprep/main/prep_mag/prep_quantiles_papercites.py
@@ -21,17 +21,11 @@ import sys
 import numpy as np
 import logging 
 import itertools 
-
+from helpers.functions import enumerated_arguments
 
 from helpers.variables import db_file, keep_doctypes_citations, insert_questionmark_doctypes_citations
 
 logging.basicConfig(level=logging.INFO)
-
-
-def enumerated_arguments(*args):
-    "from a generator *args, yield a tuple (i, *args[i]) for i in range(len(args))."
-    for i, k in enumerate(*args):
-        yield ((i,) + tuple([j for j in k]))
 
 
 def calculate_quantiles(

--- a/src/dataprep/pipeline.sh
+++ b/src/dataprep/pipeline.sh
@@ -32,6 +32,8 @@ python3 $script_path/prep_mag/paper_fields.py &> $logfile_path/paper_fields.log
 python3 $script_path/prep_mag/prep_authors.py --years_first_field 5 \
     --years_last_field 5 &> $logfile_path/prep_authors.log
 
+python -m $script_path.prep_mag.authors_fields_detailed &> $logfile_path/authors_fields_detailed.log
+
 python3 -m $script_path.prep_mag.prep_collab --nauthors "all" --chunksize 10000 --ncores 10 \
     &> $logfile_path/prep_collab.log
 python3 -m $script_path.prep_mag.read_collab &> $logfile_path/read_collab.log
@@ -66,7 +68,7 @@ python3 $script_path/prep_mag/author_info_linking.py --years_first_field 7 \
 python -m $script_path.prep_mag.author_field0 \
     &> $logfile_path/author_field0.log
 
-python3 -m $script_path.prep_mag.affiliation_outcomes --fos_max_level 2 \
+python3 -m $script_path.prep_mag.affiliation_outcomes --fos_max_level 0 \
     &> $logfile_path/affiliation_outcomes.log #note: script_path should omit the / at the end
 
 
@@ -138,3 +140,15 @@ bash $script_path/link/grants.sh $logfile_path
 python -m $script_path.link.prep_linked_data \
     --filter_trainname "christoph_" \
     &> $logfile_path/prep_linked_data.log
+
+# # Calculate topic overlap between linked graduates and 
+    # possible new employers & colleagues
+python -m $script_path.link.topic_similarity \
+    --top_n_authors 200 \
+    --write_dir similarities_temp/ \
+    --window_size 5 \
+    &> $logfile_path/topic_similarity.log
+
+python -m  $script_path.link.read_topic_similarity \
+    --read_dir similarities_temp/ \
+    &> $logfile/read_topic_similarity.log

--- a/src/dataprep/pipeline.sh
+++ b/src/dataprep/pipeline.sh
@@ -151,4 +151,4 @@ python -m $script_path.link.topic_similarity \
 
 python -m  $script_path.link.read_topic_similarity \
     --read_dir similarities_temp/ \
-    &> $logfile/read_topic_similarity.log
+    &> $logfile_path/read_topic_similarity.log

--- a/src/dataprep/temp/affiliation_outcomes.log
+++ b/src/dataprep/temp/affiliation_outcomes.log
@@ -1,9 +1,9 @@
-Start time: 1675020333.8112402 
+Start time: 1677360458.6937292 
 
 Creating temp tables paper_affiliation_year and author_affiliation_year
+INFO:root:Creating table affiliation_outcomes
+INFO:root:Creating table affiliation_fields
 Creating tables affiliation_outcomes_temp and author_affiliation_field
-Creating table affiliation_outcomes
-Creating table affiliation_fields
 Running ANALYZE... 
 
-Done in 145.7714076677958 minutes.
+Done in 141.18910536766052 minutes.

--- a/src/dataprep/temp/authors_fields_detailed.log
+++ b/src/dataprep/temp/authors_fields_detailed.log
@@ -1,0 +1,5 @@
+Start time: 1676157927.2012737 
+
+Running ANALYZE... 
+
+Done in 362.9280607938766 minutes.

--- a/src/dataprep/temp/read_topic_similarity.log
+++ b/src/dataprep/temp/read_topic_similarity.log
@@ -1,0 +1,4 @@
+INFO:root:Combining files into one
+Running ANALYZE... 
+
+Done in 53.88206276893616 minutes.

--- a/src/dataprep/temp/topic_similarity.log
+++ b/src/dataprep/temp/topic_similarity.log
@@ -47,79 +47,53 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 2 itergroups 
-            and 410 affiliation ids 
-INFO:root:Have 3 itergroups 
-            and 391 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 9 itergroups 
-            and 323 affiliation ids 
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 51 itergroups 
-            and 388 affiliation ids 
-INFO:root:Have 21 itergroups 
-            and 634 affiliation ids 
-INFO:root:Have 42 itergroups 
-            and 491 affiliation ids 
-INFO:root:Have 43 itergroups 
-            and 356 affiliation ids 
-INFO:root:Have 68 itergroups 
-            and 474 affiliation ids 
-INFO:root:Have 69 itergroups 
-            and 408 affiliation ids 
-INFO:root:Have 57 itergroups 
-            and 764 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 129 itergroups 
-            and 571 affiliation ids 
 INFO:root:getting student data
-INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:getting student data
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 118 itergroups 
-            and 598 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:Have 300 itergroups 
-            and 844 affiliation ids 
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 251 itergroups 
-            and 610 affiliation ids 
-INFO:root:Have 107 itergroups 
-            and 546 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
@@ -127,323 +101,201 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 323 itergroups 
-            and 699 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 5 itergroups 
-            and 554 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 109 itergroups 
-            and 432 affiliation ids 
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 12 itergroups 
-            and 337 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:Have 3 itergroups 
-            and 415 affiliation ids 
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 4 itergroups 
-            and 411 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 24 itergroups 
-            and 666 affiliation ids 
-INFO:root:Have 78 itergroups 
-            and 512 affiliation ids 
-INFO:root:Have 80 itergroups 
-            and 417 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 144 itergroups 
-            and 585 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 277 itergroups 
-            and 632 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 143 itergroups 
-            and 559 affiliation ids 
-INFO:root:Have 73 itergroups 
-            and 781 affiliation ids 
-INFO:root:Have 167 itergroups 
-            and 624 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:Have 255 itergroups 
-            and 729 affiliation ids 
-INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 348 itergroups 
-            and 717 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 73 itergroups 
-            and 400 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 320 itergroups 
-            and 869 affiliation ids 
-INFO:root:Have 52 itergroups 
-            and 367 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 71 itergroups 
-            and 531 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 4 itergroups 
-            and 404 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 122 itergroups 
-            and 463 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 9 itergroups 
-            and 327 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 2 itergroups 
-            and 412 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 6 itergroups 
-            and 573 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 79 itergroups 
-            and 413 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 85 itergroups 
-            and 490 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 20 itergroups 
-            and 646 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 253 itergroups 
-            and 621 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 274 itergroups 
-            and 762 affiliation ids 
-INFO:root:Have 138 itergroups 
-            and 577 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 126 itergroups 
-            and 552 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 64 itergroups 
-            and 391 affiliation ids 
-INFO:root:Have 58 itergroups 
-            and 770 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 39 itergroups 
-            and 363 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 133 itergroups 
-            and 609 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 5 itergroups 
-            and 414 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 306 itergroups 
-            and 857 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 72 itergroups 
-            and 514 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 334 itergroups 
-            and 700 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 6 itergroups 
-            and 562 affiliation ids 
+INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 116 itergroups 
-            and 451 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 15 itergroups 
-            and 345 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 2 itergroups 
-            and 426 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 73 itergroups 
-            and 421 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 88 itergroups 
-            and 527 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 17 itergroups 
-            and 686 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 267 itergroups 
-            and 747 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:Have 148 itergroups 
-            and 607 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
-INFO:root:Have 284 itergroups 
-            and 637 affiliation ids 
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 182 itergroups 
-            and 634 affiliation ids 
-INFO:root:Have 72 itergroups 
-            and 801 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:Have 86 itergroups 
-            and 413 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
-INFO:root:Have 162 itergroups 
-            and 573 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
@@ -451,46 +303,39 @@ INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 51 itergroups 
-            and 368 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 347 itergroups 
-            and 722 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 328 itergroups 
-            and 886 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 84 itergroups 
-            and 545 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 5 itergroups 
-            and 425 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 6 itergroups 
-            and 571 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 143 itergroups 
-            and 476 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -502,113 +347,75 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 12 itergroups 
-            and 361 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 2 itergroups 
-            and 431 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 85 itergroups 
-            and 423 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 93 itergroups 
-            and 546 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 24 itergroups 
-            and 695 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 162 itergroups 
-            and 619 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
-INFO:root:Have 285 itergroups 
-            and 769 affiliation ids 
-INFO:root:Have 295 itergroups 
-            and 653 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:Have 166 itergroups 
-            and 585 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 74 itergroups 
-            and 813 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 95 itergroups 
-            and 419 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 50 itergroups 
-            and 374 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 359 itergroups 
-            and 727 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:Have 194 itergroups 
-            and 663 affiliation ids 
-INFO:root:Have 99 itergroups 
-            and 574 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 348 itergroups 
-            and 908 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 4 itergroups 
-            and 443 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
-INFO:root:getting student data
-INFO:root:Have 132 itergroups 
-            and 489 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 10 itergroups 
-            and 582 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -616,106 +423,69 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 13 itergroups 
-            and 382 affiliation ids 
-INFO:root:Have 3 itergroups 
-            and 439 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 90 itergroups 
-            and 430 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 87 itergroups 
-            and 584 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 31 itergroups 
-            and 732 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 170 itergroups 
-            and 661 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 309 itergroups 
-            and 674 affiliation ids 
-INFO:root:Have 297 itergroups 
-            and 792 affiliation ids 
-INFO:root:Have 219 itergroups 
-            and 705 affiliation ids 
-INFO:root:Have 186 itergroups 
-            and 607 affiliation ids 
-INFO:root:Have 123 itergroups 
-            and 442 affiliation ids 
-INFO:root:Have 92 itergroups 
-            and 848 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:Have 44 itergroups 
-            and 393 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 116 itergroups 
-            and 625 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 363 itergroups 
-            and 939 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:Have 380 itergroups 
-            and 758 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 16 itergroups 
-            and 603 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 151 itergroups 
-            and 502 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -725,159 +495,102 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 330 itergroups 
-            and 836 affiliation ids 
-INFO:root:Have 34 itergroups 
-            and 611 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 203 itergroups 
-            and 796 affiliation ids 
-INFO:root:Have 148 itergroups 
-            and 583 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 16 itergroups 
-            and 645 affiliation ids 
-INFO:root:Have 97 itergroups 
-            and 610 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 179 itergroups 
-            and 959 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 319 itergroups 
-            and 863 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
-INFO:root:getting student data
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 548 itergroups 
-            and 913 affiliation ids 
-INFO:root:Have 330 itergroups 
-            and 1086 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 278 itergroups 
-            and 639 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 164 itergroups 
-            and 625 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
-INFO:root:Have 557 itergroups 
-            and 979 affiliation ids 
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 374 itergroups 
-            and 875 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
-INFO:root:Have 14 itergroups 
-            and 532 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:getting student data
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 787 itergroups 
-            and 1126 affiliation ids 
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 809 itergroups 
-            and 1036 affiliation ids 
-INFO:root:Have 10 itergroups 
-            and 566 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:Have 121 itergroups 
-            and 537 affiliation ids 
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 143 itergroups 
-            and 728 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 46 itergroups 
-            and 511 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 80 itergroups 
-            and 882 affiliation ids 
-INFO:root:Have 387 itergroups 
-            and 881 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 348 itergroups 
-            and 711 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 94 itergroups 
-            and 855 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 263 itergroups 
-            and 794 affiliation ids 
-INFO:root:Have 421 itergroups 
-            and 822 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -885,49 +598,46 @@ INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 380 itergroups 
-            and 900 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 190 itergroups 
-            and 565 affiliation ids 
-INFO:root:Have 221 itergroups 
-            and 1005 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:Have 245 itergroups 
-            and 773 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 247 itergroups 
-            and 782 affiliation ids 
-INFO:root:Have 106 itergroups 
-            and 530 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 25 itergroups 
-            and 593 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 586 itergroups 
-            and 1064 affiliation ids 
-INFO:root:Have 621 itergroups 
-            and 959 affiliation ids 
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
@@ -936,212 +646,156 @@ INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 30 itergroups 
-            and 797 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 227 itergroups 
-            and 651 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
-INFO:root:Have 15 itergroups 
-            and 640 affiliation ids 
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 146 itergroups 
-            and 579 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 200 itergroups 
-            and 780 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 89 itergroups 
-            and 596 affiliation ids 
+INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 765 itergroups 
-            and 1087 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 163 itergroups 
-            and 930 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 325 itergroups 
-            and 848 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 532 itergroups 
-            and 895 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 266 itergroups 
-            and 630 affiliation ids 
-INFO:root:Have 549 itergroups 
-            and 974 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 322 itergroups 
-            and 1076 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 384 itergroups 
-            and 873 affiliation ids 
-INFO:root:Have 149 itergroups 
-            and 608 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 326 itergroups 
-            and 865 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 21 itergroups 
-            and 588 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 709 itergroups 
-            and 1119 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 785 itergroups 
-            and 1018 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 544 itergroups 
-            and 1006 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 75 itergroups 
-            and 873 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 19 itergroups 
-            and 626 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 318 itergroups 
-            and 698 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 134 itergroups 
-            and 572 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 192 itergroups 
-            and 778 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 76 itergroups 
-            and 582 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 160 itergroups 
-            and 919 affiliation ids 
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 321 itergroups 
-            and 832 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 501 itergroups 
-            and 876 affiliation ids 
-INFO:root:Have 6 itergroups 
-            and 478 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 263 itergroups 
-            and 618 affiliation ids 
-INFO:root:Have 528 itergroups 
-            and 963 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 299 itergroups 
-            and 1053 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 142 itergroups 
-            and 592 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 295 itergroups 
-            and 850 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
@@ -1149,275 +803,202 @@ INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 346 itergroups 
-            and 852 affiliation ids 
-INFO:root:Have 681 itergroups 
-            and 1110 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 17 itergroups 
-            and 414 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 739 itergroups 
-            and 1008 affiliation ids 
-INFO:root:Have 4 itergroups 
-            and 458 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 71 itergroups 
-            and 861 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 291 itergroups 
-            and 691 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:Have 85 itergroups 
-            and 458 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 112 itergroups 
-            and 627 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 47 itergroups 
-            and 758 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 191 itergroups 
-            and 708 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 329 itergroups 
-            and 711 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 127 itergroups 
-            and 902 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 692 itergroups 
-            and 1073 affiliation ids 
-INFO:root:Have 192 itergroups 
-            and 660 affiliation ids 
-INFO:root:Have 135 itergroups 
-            and 476 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 69 itergroups 
-            and 427 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 250 itergroups 
-            and 755 affiliation ids 
-INFO:root:similarity to faculty
-INFO:root:Have 160 itergroups 
-            and 691 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 423 itergroups 
-            and 982 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 433 itergroups 
-            and 816 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 13 itergroups 
-            and 523 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 168 itergroups 
-            and 536 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 15 itergroups 
-            and 648 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:getting student data
-INFO:root:Have 11 itergroups 
-            and 555 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 120 itergroups 
-            and 525 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 48 itergroups 
-            and 499 affiliation ids 
-INFO:root:Have 149 itergroups 
-            and 707 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 84 itergroups 
-            and 835 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 236 itergroups 
-            and 789 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 660 itergroups 
-            and 1055 affiliation ids 
-INFO:root:Have 395 itergroups 
-            and 804 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 186 itergroups 
-            and 555 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 211 itergroups 
-            and 988 affiliation ids 
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 236 itergroups 
-            and 777 affiliation ids 
-INFO:root:Have 99 itergroups 
-            and 510 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 357 itergroups 
-            and 888 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 19 itergroups 
-            and 549 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 246 itergroups 
-            and 752 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 547 itergroups 
-            and 1054 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 368 itergroups 
-            and 889 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 10 itergroups 
-            and 589 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 43 itergroups 
-            and 774 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 590 itergroups 
-            and 944 affiliation ids 
-INFO:root:Have 215 itergroups 
-            and 635 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 119 itergroups 
-            and 557 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -1425,266 +1006,203 @@ INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 61 itergroups 
-            and 546 affiliation ids 
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 155 itergroups 
-            and 750 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 112 itergroups 
-            and 893 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 292 itergroups 
-            and 819 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 462 itergroups 
-            and 854 affiliation ids 
-INFO:root:Have 224 itergroups 
-            and 590 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 265 itergroups 
-            and 1029 affiliation ids 
-INFO:root:Have 13 itergroups 
-            and 516 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 449 itergroups 
-            and 937 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 126 itergroups 
-            and 567 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 270 itergroups 
-            and 809 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 271 itergroups 
-            and 812 affiliation ids 
-INFO:root:Have 629 itergroups 
-            and 1087 affiliation ids 
-INFO:root:Have 660 itergroups 
-            and 992 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 8 itergroups 
-            and 532 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 50 itergroups 
-            and 838 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 257 itergroups 
-            and 677 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:getting student data
-INFO:root:Have 93 itergroups 
-            and 517 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 145 itergroups 
-            and 694 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 38 itergroups 
-            and 483 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 499 itergroups 
-            and 986 affiliation ids 
-INFO:root:Have 79 itergroups 
-            and 822 affiliation ids 
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 236 itergroups 
-            and 776 affiliation ids 
-INFO:root:Have 396 itergroups 
-            and 793 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 7 itergroups 
-            and 459 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 174 itergroups 
-            and 542 affiliation ids 
-INFO:root:Have 221 itergroups 
-            and 976 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 229 itergroups 
-            and 762 affiliation ids 
-INFO:root:Have 99 itergroups 
-            and 486 affiliation ids 
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 232 itergroups 
-            and 742 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 343 itergroups 
-            and 866 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 519 itergroups 
-            and 1039 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 13 itergroups 
-            and 409 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 575 itergroups 
-            and 928 affiliation ids 
-INFO:root:Have 30 itergroups 
-            and 751 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 4 itergroups 
-            and 448 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 209 itergroups 
-            and 621 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 76 itergroups 
-            and 446 affiliation ids 
-INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
-INFO:root:Have 93 itergroups 
-            and 605 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 44 itergroups 
-            and 752 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 186 itergroups 
-            and 700 affiliation ids 
-INFO:root:Have 325 itergroups 
-            and 702 affiliation ids 
-INFO:root:Have 601 itergroups 
-            and 1033 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 129 itergroups 
-            and 467 affiliation ids 
-INFO:root:Have 71 itergroups 
-            and 417 affiliation ids 
-INFO:root:Have 122 itergroups 
-            and 883 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -1694,26 +1212,18 @@ INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 197 itergroups 
-            and 642 affiliation ids 
-INFO:root:Have 235 itergroups 
-            and 740 affiliation ids 
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 404 itergroups 
-            and 963 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 145 itergroups 
-            and 676 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 414 itergroups 
-            and 797 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to closest collaborator
@@ -1723,554 +1233,352 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 8 itergroups 
-            and 487 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 6 itergroups 
-            and 470 affiliation ids 
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 17 itergroups 
-            and 636 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 158 itergroups 
-            and 521 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 16 itergroups 
-            and 441 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 80 itergroups 
-            and 479 affiliation ids 
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 50 itergroups 
-            and 768 affiliation ids 
-INFO:root:Have 116 itergroups 
-            and 659 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 479 itergroups 
-            and 976 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 197 itergroups 
-            and 723 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 142 itergroups 
-            and 504 affiliation ids 
-INFO:root:Have 138 itergroups 
-            and 913 affiliation ids 
-INFO:root:Have 344 itergroups 
-            and 741 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 265 itergroups 
-            and 790 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:Have 205 itergroups 
-            and 695 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 351 itergroups 
-            and 878 affiliation ids 
-INFO:root:Have 165 itergroups 
-            and 727 affiliation ids 
-INFO:root:Have 90 itergroups 
-            and 443 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 439 itergroups 
-            and 1008 affiliation ids 
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 475 itergroups 
-            and 853 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 17 itergroups 
-            and 574 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 22 itergroups 
-            and 677 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 14 itergroups 
-            and 611 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 179 itergroups 
-            and 569 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 74 itergroups 
-            and 566 affiliation ids 
-INFO:root:Have 169 itergroups 
-            and 760 affiliation ids 
-INFO:root:Have 129 itergroups 
-            and 566 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 130 itergroups 
-            and 910 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 311 itergroups 
-            and 830 affiliation ids 
-INFO:root:Have 493 itergroups 
-            and 866 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 6 itergroups 
-            and 434 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 246 itergroups 
-            and 602 affiliation ids 
-INFO:root:Have 286 itergroups 
-            and 1039 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 284 itergroups 
-            and 827 affiliation ids 
-INFO:root:Have 134 itergroups 
-            and 573 affiliation ids 
-INFO:root:Have 513 itergroups 
-            and 951 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 282 itergroups 
-            and 832 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 13 itergroups 
-            and 366 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 662 itergroups 
-            and 1099 affiliation ids 
-INFO:root:Have 3 itergroups 
-            and 443 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 84 itergroups 
-            and 432 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 393 itergroups 
-            and 914 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 696 itergroups 
-            and 1004 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 58 itergroups 
-            and 857 affiliation ids 
-INFO:root:Have 91 itergroups 
-            and 566 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 279 itergroups 
-            and 680 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 22 itergroups 
-            and 708 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 172 itergroups 
-            and 642 affiliation ids 
-INFO:root:Have 299 itergroups 
-            and 669 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 104 itergroups 
-            and 432 affiliation ids 
-INFO:root:Have 92 itergroups 
-            and 837 affiliation ids 
-INFO:root:Have 206 itergroups 
-            and 684 affiliation ids 
-INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:getting student data
-INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 175 itergroups 
-            and 597 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 10 itergroups 
-            and 588 affiliation ids 
-INFO:root:Have 106 itergroups 
-            and 600 affiliation ids 
-INFO:root:Have 62 itergroups 
-            and 382 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 359 itergroups 
-            and 926 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 367 itergroups 
-            and 739 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 8 itergroups 
-            and 505 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 147 itergroups 
-            and 494 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 7 itergroups 
-            and 502 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 24 itergroups 
-            and 455 affiliation ids 
-INFO:root:Have 57 itergroups 
-            and 789 affiliation ids 
-INFO:root:Have 109 itergroups 
-            and 679 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:Have 93 itergroups 
-            and 497 affiliation ids 
-INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 305 itergroups 
-            and 813 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 368 itergroups 
-            and 769 affiliation ids 
-INFO:root:Have 154 itergroups 
-            and 522 affiliation ids 
-INFO:root:Have 225 itergroups 
-            and 759 affiliation ids 
-INFO:root:Have 163 itergroups 
-            and 940 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 211 itergroups 
-            and 723 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to closest collaborator
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 200 itergroups 
-            and 744 affiliation ids 
-INFO:root:Have 91 itergroups 
-            and 471 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 296 itergroups 
-            and 827 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 475 itergroups 
-            and 1019 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:Have 631 itergroups 
-            and 1044 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 8 itergroups 
-            and 497 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
-INFO:root:Have 7 itergroups 
-            and 493 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 29 itergroups 
-            and 714 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 523 itergroups 
-            and 894 affiliation ids 
-INFO:root:Have 24 itergroups 
-            and 441 affiliation ids 
-INFO:root:Have 104 itergroups 
-            and 667 affiliation ids 
-INFO:root:Have 91 itergroups 
-            and 492 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 192 itergroups 
-            and 597 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 52 itergroups 
-            and 776 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 210 itergroups 
-            and 739 affiliation ids 
-INFO:root:Have 364 itergroups 
-            and 751 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 149 itergroups 
-            and 510 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 8 itergroups 
-            and 483 affiliation ids 
-INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 164 itergroups 
-            and 928 affiliation ids 
-INFO:root:Have 201 itergroups 
-            and 703 affiliation ids 
-INFO:root:Have 266 itergroups 
-            and 804 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -2285,93 +1593,48 @@ INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 468 itergroups 
-            and 1015 affiliation ids 
-INFO:root:Have 17 itergroups 
-            and 428 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 81 itergroups 
-            and 455 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 496 itergroups 
-            and 877 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:Have 183 itergroups 
-            and 734 affiliation ids 
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:Have 25 itergroups 
-            and 689 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 5 itergroups 
-            and 460 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 83 itergroups 
-            and 470 affiliation ids 
-INFO:root:Have 179 itergroups 
-            and 587 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 99 itergroups 
-            and 640 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 50 itergroups 
-            and 767 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 197 itergroups 
-            and 716 affiliation ids 
-INFO:root:Have 443 itergroups 
-            and 942 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 330 itergroups 
-            and 733 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 133 itergroups 
-            and 491 affiliation ids 
-INFO:root:Have 70 itergroups 
-            and 429 affiliation ids 
-INFO:root:Have 150 itergroups 
-            and 902 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 203 itergroups 
-            and 675 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
@@ -2379,236 +1642,143 @@ INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 158 itergroups 
-            and 705 affiliation ids 
-INFO:root:Have 435 itergroups 
-            and 994 affiliation ids 
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 265 itergroups 
-            and 774 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 23 itergroups 
-            and 663 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 173 itergroups 
-            and 559 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 455 itergroups 
-            and 839 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:Have 405 itergroups 
-            and 930 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 32 itergroups 
-            and 626 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 18 itergroups 
-            and 653 affiliation ids 
-INFO:root:Have 98 itergroups 
-            and 630 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to closest collaborator
-INFO:root:Have 169 itergroups 
-            and 594 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 188 itergroups 
-            and 972 affiliation ids 
-INFO:root:Have 200 itergroups 
-            and 805 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 380 itergroups 
-            and 872 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 569 itergroups 
-            and 924 affiliation ids 
-INFO:root:Have 7 itergroups 
-            and 460 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 287 itergroups 
-            and 655 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 336 itergroups 
-            and 1090 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 424 itergroups 
-            and 893 affiliation ids 
-INFO:root:Have 386 itergroups 
-            and 901 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 14 itergroups 
-            and 398 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
 INFO:root:getting student data
-INFO:root:Have 548 itergroups 
-            and 989 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 85 itergroups 
-            and 440 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 149 itergroups 
-            and 638 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 3 itergroups 
-            and 442 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 369 itergroups 
-            and 898 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 98 itergroups 
-            and 895 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
+INFO:root:getting student data
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 831 itergroups 
-            and 1132 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 841 itergroups 
-            and 1051 affiliation ids 
-INFO:root:Have 95 itergroups 
-            and 592 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 361 itergroups 
-            and 727 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 32 itergroups 
-            and 739 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:similarity to closest collaborator
-INFO:root:Have 131 itergroups 
-            and 454 affiliation ids 
-INFO:root:Have 116 itergroups 
-            and 861 affiliation ids 
-INFO:root:Have 168 itergroups 
-            and 685 affiliation ids 
 INFO:root:getting student data
-INFO:root:Have 321 itergroups 
-            and 687 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 71 itergroups 
-            and 403 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 389 itergroups 
-            and 958 affiliation ids 
-INFO:root:Have 228 itergroups 
-            and 725 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
@@ -2616,113 +1786,77 @@ INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 186 itergroups 
-            and 622 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 129 itergroups 
-            and 651 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 15 itergroups 
-            and 545 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 399 itergroups 
-            and 779 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 11 itergroups 
-            and 577 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 13 itergroups 
-            and 623 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 152 itergroups 
-            and 515 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 57 itergroups 
-            and 529 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
-INFO:root:Have 152 itergroups 
-            and 737 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 112 itergroups 
-            and 537 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 104 itergroups 
-            and 867 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 288 itergroups 
-            and 807 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 434 itergroups 
-            and 836 affiliation ids 
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 261 itergroups 
-            and 1019 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 200 itergroups 
-            and 573 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 393 itergroups 
-            and 920 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 10 itergroups 
-            and 510 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 117 itergroups 
-            and 546 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
@@ -2730,272 +1864,187 @@ INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 274 itergroups 
-            and 788 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 259 itergroups 
-            and 793 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 817 itergroups 
-            and 1095 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 594 itergroups 
-            and 1073 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 345 itergroups 
-            and 858 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 40 itergroups 
-            and 822 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 643 itergroups 
-            and 976 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:Have 8 itergroups 
-            and 517 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 232 itergroups 
-            and 665 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 90 itergroups 
-            and 508 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 29 itergroups 
-            and 475 affiliation ids 
-INFO:root:Have 126 itergroups 
-            and 694 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 72 itergroups 
-            and 808 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 223 itergroups 
-            and 768 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 376 itergroups 
-            and 786 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 161 itergroups 
-            and 528 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 195 itergroups 
-            and 954 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 217 itergroups 
-            and 730 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 198 itergroups 
-            and 752 affiliation ids 
-INFO:root:Have 89 itergroups 
-            and 476 affiliation ids 
-INFO:root:Have 501 itergroups 
-            and 1029 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:Have 311 itergroups 
-            and 856 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 24 itergroups 
-            and 729 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 552 itergroups 
-            and 918 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 194 itergroups 
-            and 605 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 26 itergroups 
-            and 646 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 163 itergroups 
-            and 643 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 184 itergroups 
-            and 844 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 17 itergroups 
-            and 669 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 136 itergroups 
-            and 696 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 576 itergroups 
-            and 1026 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 206 itergroups 
-            and 1000 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 618 itergroups 
-            and 976 affiliation ids 
-INFO:root:Have 384 itergroups 
-            and 886 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 345 itergroups 
-            and 1103 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 301 itergroups 
-            and 691 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 195 itergroups 
-            and 693 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 530 itergroups 
-            and 1019 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 440 itergroups 
-            and 947 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 895 itergroups 
-            and 1153 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:Have 369 itergroups 
-            and 931 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 455 itergroups 
-            and 959 affiliation ids 
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 67 itergroups 
-            and 911 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 886 itergroups 
-            and 1090 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 34 itergroups 
-            and 630 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 367 itergroups 
-            and 765 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
@@ -3004,309 +2053,174 @@ INFO:root:getting student data
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 150 itergroups 
-            and 599 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 198 itergroups 
-            and 815 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 85 itergroups 
-            and 650 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 18 itergroups 
-            and 663 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 153 itergroups 
-            and 982 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 590 itergroups 
-            and 936 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 291 itergroups 
-            and 667 affiliation ids 
-INFO:root:Have 347 itergroups 
-            and 1093 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to faculty
-INFO:root:Have 370 itergroups 
-            and 910 affiliation ids 
-INFO:root:Have 154 itergroups 
-            and 651 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 533 itergroups 
-            and 1001 affiliation ids 
-INFO:root:Have 431 itergroups 
-            and 908 affiliation ids 
-INFO:root:Have 381 itergroups 
-            and 872 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 834 itergroups 
-            and 1137 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 29 itergroups 
-            and 639 affiliation ids 
-INFO:root:Have 99 itergroups 
-            and 904 affiliation ids 
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 369 itergroups 
-            and 732 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 843 itergroups 
-            and 1063 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 155 itergroups 
-            and 609 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 97 itergroups 
-            and 659 affiliation ids 
-INFO:root:Have 213 itergroups 
-            and 819 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 18 itergroups 
-            and 665 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 175 itergroups 
-            and 985 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 902 itergroups 
-            and 1130 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 383 itergroups 
-            and 876 affiliation ids 
-INFO:root:Have 604 itergroups 
-            and 945 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 344 itergroups 
-            and 1099 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 290 itergroups 
-            and 676 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 545 itergroups 
-            and 1003 affiliation ids 
 INFO:root:similarity to closest collaborator
-INFO:root:Have 167 itergroups 
-            and 660 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 447 itergroups 
-            and 918 affiliation ids 
-INFO:root:Have 855 itergroups 
-            and 1144 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 95 itergroups 
-            and 910 affiliation ids 
-INFO:root:Have 375 itergroups 
-            and 923 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 27 itergroups 
-            and 644 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 858 itergroups 
-            and 1078 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 360 itergroups 
-            and 736 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 196 itergroups 
-            and 831 affiliation ids 
-INFO:root:Have 173 itergroups 
-            and 630 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 110 itergroups 
-            and 680 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 835 itergroups 
-            and 1106 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 17 itergroups 
-            and 667 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 188 itergroups 
-            and 998 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 623 itergroups 
-            and 964 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to closest collaborator
-INFO:root:Have 394 itergroups 
-            and 887 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 356 itergroups 
-            and 1104 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 304 itergroups 
-            and 683 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 376 itergroups 
-            and 928 affiliation ids 
 INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
-INFO:root:Have 169 itergroups 
-            and 684 affiliation ids 
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 532 itergroups 
-            and 1018 affiliation ids 
-INFO:root:Have 429 itergroups 
-            and 938 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
@@ -3315,223 +2229,131 @@ INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 885 itergroups 
-            and 1153 affiliation ids 
-INFO:root:Have 91 itergroups 
-            and 920 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
-INFO:root:Have 370 itergroups 
-            and 748 affiliation ids 
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 26 itergroups 
-            and 641 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 167 itergroups 
-            and 633 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:Have 871 itergroups 
-            and 1085 affiliation ids 
-INFO:root:similarity to closest collaborator
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 120 itergroups 
-            and 688 affiliation ids 
-INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 183 itergroups 
-            and 835 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:Have 25 itergroups 
-            and 668 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 188 itergroups 
-            and 1001 affiliation ids 
 INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 862 itergroups 
-            and 1117 affiliation ids 
-INFO:root:Have 612 itergroups 
-            and 968 affiliation ids 
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 378 itergroups 
-            and 889 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:making d_similarity_institutions
-INFO:root:Have 296 itergroups 
-            and 688 affiliation ids 
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to closest collaborator
 INFO:root:similarity to faculty
-INFO:root:Have 343 itergroups 
-            and 1104 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 193 itergroups 
-            and 691 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
-INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 466 itergroups 
-            and 949 affiliation ids 
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
-INFO:root:Have 379 itergroups 
-            and 935 affiliation ids 
-INFO:root:Have 520 itergroups 
-            and 1019 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
-INFO:root:Have 874 itergroups 
-            and 1154 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 74 itergroups 
-            and 919 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 359 itergroups 
-            and 761 affiliation ids 
-INFO:root:Have 878 itergroups 
-            and 1087 affiliation ids 
-INFO:root:Have 31 itergroups 
-            and 635 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 221 itergroups 
-            and 824 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 159 itergroups 
-            and 613 affiliation ids 
+INFO:root:similarity to closest collaborator
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:similarity to closest collaborator
-INFO:root:Have 113 itergroups 
-            and 671 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
-INFO:root:Have 20 itergroups 
-            and 666 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:making d_similarity_institutions
-INFO:root:similarity to closest collaborator
 INFO:root:getting student data
 INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 176 itergroups 
-            and 990 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 889 itergroups 
-            and 1136 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
 INFO:root:similarity to closest collaborator
 INFO:root:similarity to closest collaborator
-INFO:root:Have 612 itergroups 
-            and 955 affiliation ids 
-INFO:root:Have 387 itergroups 
-            and 880 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
-INFO:root:Have 302 itergroups 
-            and 678 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 354 itergroups 
-            and 1106 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 182 itergroups 
-            and 671 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 411 itergroups 
-            and 927 affiliation ids 
-INFO:root:Have 882 itergroups 
-            and 1145 affiliation ids 
-INFO:root:Have 586 itergroups 
-            and 1015 affiliation ids 
-INFO:root:Have 428 itergroups 
-            and 926 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
-INFO:root:Have 90 itergroups 
-            and 911 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
-INFO:root:Have 866 itergroups 
-            and 1085 affiliation ids 
-INFO:root:Have 359 itergroups 
-            and 746 affiliation ids 
 INFO:root:making d_similarity_institutions
 INFO:root:making d_similarity_institutions
-INFO:root:Have 891 itergroups 
-            and 1135 affiliation ids 
 INFO:root:making d_similarity_institutions
-INFO:root:Have 870 itergroups 
-            and 1129 affiliation ids 
 INFO:root:making d_similarity_institutions
 --queries finished.
-Done in 1130.5763326883316 minutes.
+Done in 621.0275359471639 minutes.

--- a/src/dataprep/temp/topic_similarity.log
+++ b/src/dataprep/temp/topic_similarity.log
@@ -1,0 +1,3537 @@
+INFO:root:Running queries
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 2 itergroups 
+            and 410 affiliation ids 
+INFO:root:Have 3 itergroups 
+            and 391 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 9 itergroups 
+            and 323 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 51 itergroups 
+            and 388 affiliation ids 
+INFO:root:Have 21 itergroups 
+            and 634 affiliation ids 
+INFO:root:Have 42 itergroups 
+            and 491 affiliation ids 
+INFO:root:Have 43 itergroups 
+            and 356 affiliation ids 
+INFO:root:Have 68 itergroups 
+            and 474 affiliation ids 
+INFO:root:Have 69 itergroups 
+            and 408 affiliation ids 
+INFO:root:Have 57 itergroups 
+            and 764 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 129 itergroups 
+            and 571 affiliation ids 
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 118 itergroups 
+            and 598 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:Have 300 itergroups 
+            and 844 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 251 itergroups 
+            and 610 affiliation ids 
+INFO:root:Have 107 itergroups 
+            and 546 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 323 itergroups 
+            and 699 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 5 itergroups 
+            and 554 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 109 itergroups 
+            and 432 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 12 itergroups 
+            and 337 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 3 itergroups 
+            and 415 affiliation ids 
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 4 itergroups 
+            and 411 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 24 itergroups 
+            and 666 affiliation ids 
+INFO:root:Have 78 itergroups 
+            and 512 affiliation ids 
+INFO:root:Have 80 itergroups 
+            and 417 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 144 itergroups 
+            and 585 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 277 itergroups 
+            and 632 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 143 itergroups 
+            and 559 affiliation ids 
+INFO:root:Have 73 itergroups 
+            and 781 affiliation ids 
+INFO:root:Have 167 itergroups 
+            and 624 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:Have 255 itergroups 
+            and 729 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 348 itergroups 
+            and 717 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 73 itergroups 
+            and 400 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 320 itergroups 
+            and 869 affiliation ids 
+INFO:root:Have 52 itergroups 
+            and 367 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 71 itergroups 
+            and 531 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 4 itergroups 
+            and 404 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 122 itergroups 
+            and 463 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 9 itergroups 
+            and 327 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 2 itergroups 
+            and 412 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 6 itergroups 
+            and 573 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 79 itergroups 
+            and 413 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 85 itergroups 
+            and 490 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 20 itergroups 
+            and 646 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 253 itergroups 
+            and 621 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 274 itergroups 
+            and 762 affiliation ids 
+INFO:root:Have 138 itergroups 
+            and 577 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 126 itergroups 
+            and 552 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 64 itergroups 
+            and 391 affiliation ids 
+INFO:root:Have 58 itergroups 
+            and 770 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 39 itergroups 
+            and 363 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 133 itergroups 
+            and 609 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 5 itergroups 
+            and 414 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 306 itergroups 
+            and 857 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 72 itergroups 
+            and 514 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 334 itergroups 
+            and 700 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 6 itergroups 
+            and 562 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 116 itergroups 
+            and 451 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 15 itergroups 
+            and 345 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 2 itergroups 
+            and 426 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 73 itergroups 
+            and 421 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 88 itergroups 
+            and 527 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 17 itergroups 
+            and 686 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 267 itergroups 
+            and 747 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 148 itergroups 
+            and 607 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:Have 284 itergroups 
+            and 637 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 182 itergroups 
+            and 634 affiliation ids 
+INFO:root:Have 72 itergroups 
+            and 801 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 86 itergroups 
+            and 413 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 162 itergroups 
+            and 573 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 51 itergroups 
+            and 368 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 347 itergroups 
+            and 722 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 328 itergroups 
+            and 886 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 84 itergroups 
+            and 545 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 5 itergroups 
+            and 425 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 6 itergroups 
+            and 571 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 143 itergroups 
+            and 476 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 12 itergroups 
+            and 361 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 2 itergroups 
+            and 431 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 85 itergroups 
+            and 423 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 93 itergroups 
+            and 546 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 24 itergroups 
+            and 695 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 162 itergroups 
+            and 619 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 285 itergroups 
+            and 769 affiliation ids 
+INFO:root:Have 295 itergroups 
+            and 653 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 166 itergroups 
+            and 585 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 74 itergroups 
+            and 813 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 95 itergroups 
+            and 419 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 50 itergroups 
+            and 374 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 359 itergroups 
+            and 727 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 194 itergroups 
+            and 663 affiliation ids 
+INFO:root:Have 99 itergroups 
+            and 574 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 348 itergroups 
+            and 908 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 4 itergroups 
+            and 443 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:Have 132 itergroups 
+            and 489 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 10 itergroups 
+            and 582 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 13 itergroups 
+            and 382 affiliation ids 
+INFO:root:Have 3 itergroups 
+            and 439 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 90 itergroups 
+            and 430 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 87 itergroups 
+            and 584 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 31 itergroups 
+            and 732 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 170 itergroups 
+            and 661 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 309 itergroups 
+            and 674 affiliation ids 
+INFO:root:Have 297 itergroups 
+            and 792 affiliation ids 
+INFO:root:Have 219 itergroups 
+            and 705 affiliation ids 
+INFO:root:Have 186 itergroups 
+            and 607 affiliation ids 
+INFO:root:Have 123 itergroups 
+            and 442 affiliation ids 
+INFO:root:Have 92 itergroups 
+            and 848 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:Have 44 itergroups 
+            and 393 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 116 itergroups 
+            and 625 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 363 itergroups 
+            and 939 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 380 itergroups 
+            and 758 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 16 itergroups 
+            and 603 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 151 itergroups 
+            and 502 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 330 itergroups 
+            and 836 affiliation ids 
+INFO:root:Have 34 itergroups 
+            and 611 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 203 itergroups 
+            and 796 affiliation ids 
+INFO:root:Have 148 itergroups 
+            and 583 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 16 itergroups 
+            and 645 affiliation ids 
+INFO:root:Have 97 itergroups 
+            and 610 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 179 itergroups 
+            and 959 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 319 itergroups 
+            and 863 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 548 itergroups 
+            and 913 affiliation ids 
+INFO:root:Have 330 itergroups 
+            and 1086 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 278 itergroups 
+            and 639 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 164 itergroups 
+            and 625 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:Have 557 itergroups 
+            and 979 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 374 itergroups 
+            and 875 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:Have 14 itergroups 
+            and 532 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 787 itergroups 
+            and 1126 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 809 itergroups 
+            and 1036 affiliation ids 
+INFO:root:Have 10 itergroups 
+            and 566 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:Have 121 itergroups 
+            and 537 affiliation ids 
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 143 itergroups 
+            and 728 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 46 itergroups 
+            and 511 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 80 itergroups 
+            and 882 affiliation ids 
+INFO:root:Have 387 itergroups 
+            and 881 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 348 itergroups 
+            and 711 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 94 itergroups 
+            and 855 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 263 itergroups 
+            and 794 affiliation ids 
+INFO:root:Have 421 itergroups 
+            and 822 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 380 itergroups 
+            and 900 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 190 itergroups 
+            and 565 affiliation ids 
+INFO:root:Have 221 itergroups 
+            and 1005 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 245 itergroups 
+            and 773 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 247 itergroups 
+            and 782 affiliation ids 
+INFO:root:Have 106 itergroups 
+            and 530 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 25 itergroups 
+            and 593 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 586 itergroups 
+            and 1064 affiliation ids 
+INFO:root:Have 621 itergroups 
+            and 959 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 30 itergroups 
+            and 797 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 227 itergroups 
+            and 651 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 15 itergroups 
+            and 640 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 146 itergroups 
+            and 579 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 200 itergroups 
+            and 780 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 89 itergroups 
+            and 596 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 765 itergroups 
+            and 1087 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 163 itergroups 
+            and 930 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 325 itergroups 
+            and 848 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 532 itergroups 
+            and 895 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 266 itergroups 
+            and 630 affiliation ids 
+INFO:root:Have 549 itergroups 
+            and 974 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 322 itergroups 
+            and 1076 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 384 itergroups 
+            and 873 affiliation ids 
+INFO:root:Have 149 itergroups 
+            and 608 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 326 itergroups 
+            and 865 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 21 itergroups 
+            and 588 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 709 itergroups 
+            and 1119 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 785 itergroups 
+            and 1018 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 544 itergroups 
+            and 1006 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 75 itergroups 
+            and 873 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 19 itergroups 
+            and 626 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 318 itergroups 
+            and 698 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 134 itergroups 
+            and 572 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 192 itergroups 
+            and 778 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 76 itergroups 
+            and 582 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 160 itergroups 
+            and 919 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 321 itergroups 
+            and 832 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 501 itergroups 
+            and 876 affiliation ids 
+INFO:root:Have 6 itergroups 
+            and 478 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 263 itergroups 
+            and 618 affiliation ids 
+INFO:root:Have 528 itergroups 
+            and 963 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 299 itergroups 
+            and 1053 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 142 itergroups 
+            and 592 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 295 itergroups 
+            and 850 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 346 itergroups 
+            and 852 affiliation ids 
+INFO:root:Have 681 itergroups 
+            and 1110 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 17 itergroups 
+            and 414 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 739 itergroups 
+            and 1008 affiliation ids 
+INFO:root:Have 4 itergroups 
+            and 458 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 71 itergroups 
+            and 861 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 291 itergroups 
+            and 691 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 85 itergroups 
+            and 458 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 112 itergroups 
+            and 627 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 47 itergroups 
+            and 758 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 191 itergroups 
+            and 708 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 329 itergroups 
+            and 711 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 127 itergroups 
+            and 902 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 692 itergroups 
+            and 1073 affiliation ids 
+INFO:root:Have 192 itergroups 
+            and 660 affiliation ids 
+INFO:root:Have 135 itergroups 
+            and 476 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 69 itergroups 
+            and 427 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 250 itergroups 
+            and 755 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 160 itergroups 
+            and 691 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 423 itergroups 
+            and 982 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 433 itergroups 
+            and 816 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 13 itergroups 
+            and 523 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 168 itergroups 
+            and 536 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 15 itergroups 
+            and 648 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 11 itergroups 
+            and 555 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 120 itergroups 
+            and 525 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 48 itergroups 
+            and 499 affiliation ids 
+INFO:root:Have 149 itergroups 
+            and 707 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 84 itergroups 
+            and 835 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 236 itergroups 
+            and 789 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 660 itergroups 
+            and 1055 affiliation ids 
+INFO:root:Have 395 itergroups 
+            and 804 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 186 itergroups 
+            and 555 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 211 itergroups 
+            and 988 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 236 itergroups 
+            and 777 affiliation ids 
+INFO:root:Have 99 itergroups 
+            and 510 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 357 itergroups 
+            and 888 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 19 itergroups 
+            and 549 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 246 itergroups 
+            and 752 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 547 itergroups 
+            and 1054 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 368 itergroups 
+            and 889 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 10 itergroups 
+            and 589 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 43 itergroups 
+            and 774 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 590 itergroups 
+            and 944 affiliation ids 
+INFO:root:Have 215 itergroups 
+            and 635 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 119 itergroups 
+            and 557 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 61 itergroups 
+            and 546 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 155 itergroups 
+            and 750 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 112 itergroups 
+            and 893 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 292 itergroups 
+            and 819 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 462 itergroups 
+            and 854 affiliation ids 
+INFO:root:Have 224 itergroups 
+            and 590 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 265 itergroups 
+            and 1029 affiliation ids 
+INFO:root:Have 13 itergroups 
+            and 516 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 449 itergroups 
+            and 937 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 126 itergroups 
+            and 567 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 270 itergroups 
+            and 809 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 271 itergroups 
+            and 812 affiliation ids 
+INFO:root:Have 629 itergroups 
+            and 1087 affiliation ids 
+INFO:root:Have 660 itergroups 
+            and 992 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 8 itergroups 
+            and 532 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 50 itergroups 
+            and 838 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 257 itergroups 
+            and 677 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:Have 93 itergroups 
+            and 517 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 145 itergroups 
+            and 694 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 38 itergroups 
+            and 483 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 499 itergroups 
+            and 986 affiliation ids 
+INFO:root:Have 79 itergroups 
+            and 822 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 236 itergroups 
+            and 776 affiliation ids 
+INFO:root:Have 396 itergroups 
+            and 793 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 7 itergroups 
+            and 459 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 174 itergroups 
+            and 542 affiliation ids 
+INFO:root:Have 221 itergroups 
+            and 976 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 229 itergroups 
+            and 762 affiliation ids 
+INFO:root:Have 99 itergroups 
+            and 486 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 232 itergroups 
+            and 742 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 343 itergroups 
+            and 866 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 519 itergroups 
+            and 1039 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 13 itergroups 
+            and 409 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 575 itergroups 
+            and 928 affiliation ids 
+INFO:root:Have 30 itergroups 
+            and 751 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 4 itergroups 
+            and 448 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 209 itergroups 
+            and 621 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 76 itergroups 
+            and 446 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 93 itergroups 
+            and 605 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 44 itergroups 
+            and 752 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 186 itergroups 
+            and 700 affiliation ids 
+INFO:root:Have 325 itergroups 
+            and 702 affiliation ids 
+INFO:root:Have 601 itergroups 
+            and 1033 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 129 itergroups 
+            and 467 affiliation ids 
+INFO:root:Have 71 itergroups 
+            and 417 affiliation ids 
+INFO:root:Have 122 itergroups 
+            and 883 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 197 itergroups 
+            and 642 affiliation ids 
+INFO:root:Have 235 itergroups 
+            and 740 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 404 itergroups 
+            and 963 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 145 itergroups 
+            and 676 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 414 itergroups 
+            and 797 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 8 itergroups 
+            and 487 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 6 itergroups 
+            and 470 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 17 itergroups 
+            and 636 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 158 itergroups 
+            and 521 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 16 itergroups 
+            and 441 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 80 itergroups 
+            and 479 affiliation ids 
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 50 itergroups 
+            and 768 affiliation ids 
+INFO:root:Have 116 itergroups 
+            and 659 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 479 itergroups 
+            and 976 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 197 itergroups 
+            and 723 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 142 itergroups 
+            and 504 affiliation ids 
+INFO:root:Have 138 itergroups 
+            and 913 affiliation ids 
+INFO:root:Have 344 itergroups 
+            and 741 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 265 itergroups 
+            and 790 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 205 itergroups 
+            and 695 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 351 itergroups 
+            and 878 affiliation ids 
+INFO:root:Have 165 itergroups 
+            and 727 affiliation ids 
+INFO:root:Have 90 itergroups 
+            and 443 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 439 itergroups 
+            and 1008 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 475 itergroups 
+            and 853 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 17 itergroups 
+            and 574 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 22 itergroups 
+            and 677 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 14 itergroups 
+            and 611 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 179 itergroups 
+            and 569 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 74 itergroups 
+            and 566 affiliation ids 
+INFO:root:Have 169 itergroups 
+            and 760 affiliation ids 
+INFO:root:Have 129 itergroups 
+            and 566 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 130 itergroups 
+            and 910 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 311 itergroups 
+            and 830 affiliation ids 
+INFO:root:Have 493 itergroups 
+            and 866 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 6 itergroups 
+            and 434 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 246 itergroups 
+            and 602 affiliation ids 
+INFO:root:Have 286 itergroups 
+            and 1039 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 284 itergroups 
+            and 827 affiliation ids 
+INFO:root:Have 134 itergroups 
+            and 573 affiliation ids 
+INFO:root:Have 513 itergroups 
+            and 951 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 282 itergroups 
+            and 832 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 13 itergroups 
+            and 366 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 662 itergroups 
+            and 1099 affiliation ids 
+INFO:root:Have 3 itergroups 
+            and 443 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 84 itergroups 
+            and 432 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 393 itergroups 
+            and 914 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 696 itergroups 
+            and 1004 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 58 itergroups 
+            and 857 affiliation ids 
+INFO:root:Have 91 itergroups 
+            and 566 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 279 itergroups 
+            and 680 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 22 itergroups 
+            and 708 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 172 itergroups 
+            and 642 affiliation ids 
+INFO:root:Have 299 itergroups 
+            and 669 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 104 itergroups 
+            and 432 affiliation ids 
+INFO:root:Have 92 itergroups 
+            and 837 affiliation ids 
+INFO:root:Have 206 itergroups 
+            and 684 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 175 itergroups 
+            and 597 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 10 itergroups 
+            and 588 affiliation ids 
+INFO:root:Have 106 itergroups 
+            and 600 affiliation ids 
+INFO:root:Have 62 itergroups 
+            and 382 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 359 itergroups 
+            and 926 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 367 itergroups 
+            and 739 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 8 itergroups 
+            and 505 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 147 itergroups 
+            and 494 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 7 itergroups 
+            and 502 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 24 itergroups 
+            and 455 affiliation ids 
+INFO:root:Have 57 itergroups 
+            and 789 affiliation ids 
+INFO:root:Have 109 itergroups 
+            and 679 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 93 itergroups 
+            and 497 affiliation ids 
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 305 itergroups 
+            and 813 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 368 itergroups 
+            and 769 affiliation ids 
+INFO:root:Have 154 itergroups 
+            and 522 affiliation ids 
+INFO:root:Have 225 itergroups 
+            and 759 affiliation ids 
+INFO:root:Have 163 itergroups 
+            and 940 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 211 itergroups 
+            and 723 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 200 itergroups 
+            and 744 affiliation ids 
+INFO:root:Have 91 itergroups 
+            and 471 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 296 itergroups 
+            and 827 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 475 itergroups 
+            and 1019 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 631 itergroups 
+            and 1044 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 8 itergroups 
+            and 497 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 7 itergroups 
+            and 493 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 29 itergroups 
+            and 714 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 523 itergroups 
+            and 894 affiliation ids 
+INFO:root:Have 24 itergroups 
+            and 441 affiliation ids 
+INFO:root:Have 104 itergroups 
+            and 667 affiliation ids 
+INFO:root:Have 91 itergroups 
+            and 492 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 192 itergroups 
+            and 597 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 52 itergroups 
+            and 776 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 210 itergroups 
+            and 739 affiliation ids 
+INFO:root:Have 364 itergroups 
+            and 751 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 149 itergroups 
+            and 510 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 8 itergroups 
+            and 483 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 164 itergroups 
+            and 928 affiliation ids 
+INFO:root:Have 201 itergroups 
+            and 703 affiliation ids 
+INFO:root:Have 266 itergroups 
+            and 804 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 468 itergroups 
+            and 1015 affiliation ids 
+INFO:root:Have 17 itergroups 
+            and 428 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 81 itergroups 
+            and 455 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 496 itergroups 
+            and 877 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 183 itergroups 
+            and 734 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:Have 25 itergroups 
+            and 689 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 5 itergroups 
+            and 460 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 83 itergroups 
+            and 470 affiliation ids 
+INFO:root:Have 179 itergroups 
+            and 587 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 99 itergroups 
+            and 640 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 50 itergroups 
+            and 767 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 197 itergroups 
+            and 716 affiliation ids 
+INFO:root:Have 443 itergroups 
+            and 942 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 330 itergroups 
+            and 733 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 133 itergroups 
+            and 491 affiliation ids 
+INFO:root:Have 70 itergroups 
+            and 429 affiliation ids 
+INFO:root:Have 150 itergroups 
+            and 902 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 203 itergroups 
+            and 675 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 158 itergroups 
+            and 705 affiliation ids 
+INFO:root:Have 435 itergroups 
+            and 994 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 265 itergroups 
+            and 774 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 23 itergroups 
+            and 663 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 173 itergroups 
+            and 559 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 455 itergroups 
+            and 839 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 405 itergroups 
+            and 930 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 32 itergroups 
+            and 626 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 18 itergroups 
+            and 653 affiliation ids 
+INFO:root:Have 98 itergroups 
+            and 630 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:Have 169 itergroups 
+            and 594 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 188 itergroups 
+            and 972 affiliation ids 
+INFO:root:Have 200 itergroups 
+            and 805 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 380 itergroups 
+            and 872 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 569 itergroups 
+            and 924 affiliation ids 
+INFO:root:Have 7 itergroups 
+            and 460 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 287 itergroups 
+            and 655 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 336 itergroups 
+            and 1090 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 424 itergroups 
+            and 893 affiliation ids 
+INFO:root:Have 386 itergroups 
+            and 901 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 14 itergroups 
+            and 398 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:Have 548 itergroups 
+            and 989 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 85 itergroups 
+            and 440 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 149 itergroups 
+            and 638 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 3 itergroups 
+            and 442 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 369 itergroups 
+            and 898 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 98 itergroups 
+            and 895 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 831 itergroups 
+            and 1132 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 841 itergroups 
+            and 1051 affiliation ids 
+INFO:root:Have 95 itergroups 
+            and 592 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 361 itergroups 
+            and 727 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 32 itergroups 
+            and 739 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:Have 131 itergroups 
+            and 454 affiliation ids 
+INFO:root:Have 116 itergroups 
+            and 861 affiliation ids 
+INFO:root:Have 168 itergroups 
+            and 685 affiliation ids 
+INFO:root:getting student data
+INFO:root:Have 321 itergroups 
+            and 687 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 71 itergroups 
+            and 403 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 389 itergroups 
+            and 958 affiliation ids 
+INFO:root:Have 228 itergroups 
+            and 725 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 186 itergroups 
+            and 622 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 129 itergroups 
+            and 651 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 15 itergroups 
+            and 545 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 399 itergroups 
+            and 779 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 11 itergroups 
+            and 577 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 13 itergroups 
+            and 623 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 152 itergroups 
+            and 515 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 57 itergroups 
+            and 529 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 152 itergroups 
+            and 737 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 112 itergroups 
+            and 537 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 104 itergroups 
+            and 867 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 288 itergroups 
+            and 807 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 434 itergroups 
+            and 836 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 261 itergroups 
+            and 1019 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 200 itergroups 
+            and 573 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 393 itergroups 
+            and 920 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 10 itergroups 
+            and 510 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 117 itergroups 
+            and 546 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 274 itergroups 
+            and 788 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 259 itergroups 
+            and 793 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 817 itergroups 
+            and 1095 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 594 itergroups 
+            and 1073 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 345 itergroups 
+            and 858 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 40 itergroups 
+            and 822 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:Have 643 itergroups 
+            and 976 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 8 itergroups 
+            and 517 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 232 itergroups 
+            and 665 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 90 itergroups 
+            and 508 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 29 itergroups 
+            and 475 affiliation ids 
+INFO:root:Have 126 itergroups 
+            and 694 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 72 itergroups 
+            and 808 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 223 itergroups 
+            and 768 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 376 itergroups 
+            and 786 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 161 itergroups 
+            and 528 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 195 itergroups 
+            and 954 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 217 itergroups 
+            and 730 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 198 itergroups 
+            and 752 affiliation ids 
+INFO:root:Have 89 itergroups 
+            and 476 affiliation ids 
+INFO:root:Have 501 itergroups 
+            and 1029 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 311 itergroups 
+            and 856 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 24 itergroups 
+            and 729 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 552 itergroups 
+            and 918 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 194 itergroups 
+            and 605 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 26 itergroups 
+            and 646 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 163 itergroups 
+            and 643 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 184 itergroups 
+            and 844 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 17 itergroups 
+            and 669 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 136 itergroups 
+            and 696 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 576 itergroups 
+            and 1026 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 206 itergroups 
+            and 1000 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 618 itergroups 
+            and 976 affiliation ids 
+INFO:root:Have 384 itergroups 
+            and 886 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 345 itergroups 
+            and 1103 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 301 itergroups 
+            and 691 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 195 itergroups 
+            and 693 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 530 itergroups 
+            and 1019 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 440 itergroups 
+            and 947 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 895 itergroups 
+            and 1153 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:Have 369 itergroups 
+            and 931 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 455 itergroups 
+            and 959 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 67 itergroups 
+            and 911 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 886 itergroups 
+            and 1090 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 34 itergroups 
+            and 630 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 367 itergroups 
+            and 765 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 150 itergroups 
+            and 599 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 198 itergroups 
+            and 815 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 85 itergroups 
+            and 650 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 18 itergroups 
+            and 663 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 153 itergroups 
+            and 982 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 590 itergroups 
+            and 936 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 291 itergroups 
+            and 667 affiliation ids 
+INFO:root:Have 347 itergroups 
+            and 1093 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 370 itergroups 
+            and 910 affiliation ids 
+INFO:root:Have 154 itergroups 
+            and 651 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 533 itergroups 
+            and 1001 affiliation ids 
+INFO:root:Have 431 itergroups 
+            and 908 affiliation ids 
+INFO:root:Have 381 itergroups 
+            and 872 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 834 itergroups 
+            and 1137 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:Have 29 itergroups 
+            and 639 affiliation ids 
+INFO:root:Have 99 itergroups 
+            and 904 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:Have 369 itergroups 
+            and 732 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 843 itergroups 
+            and 1063 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 155 itergroups 
+            and 609 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 97 itergroups 
+            and 659 affiliation ids 
+INFO:root:Have 213 itergroups 
+            and 819 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 18 itergroups 
+            and 665 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to faculty
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 175 itergroups 
+            and 985 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 902 itergroups 
+            and 1130 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 383 itergroups 
+            and 876 affiliation ids 
+INFO:root:Have 604 itergroups 
+            and 945 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 344 itergroups 
+            and 1099 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 290 itergroups 
+            and 676 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 545 itergroups 
+            and 1003 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:Have 167 itergroups 
+            and 660 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 447 itergroups 
+            and 918 affiliation ids 
+INFO:root:Have 855 itergroups 
+            and 1144 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 95 itergroups 
+            and 910 affiliation ids 
+INFO:root:Have 375 itergroups 
+            and 923 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 27 itergroups 
+            and 644 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 858 itergroups 
+            and 1078 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 360 itergroups 
+            and 736 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 196 itergroups 
+            and 831 affiliation ids 
+INFO:root:Have 173 itergroups 
+            and 630 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 110 itergroups 
+            and 680 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 835 itergroups 
+            and 1106 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 17 itergroups 
+            and 667 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 188 itergroups 
+            and 998 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 623 itergroups 
+            and 964 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 394 itergroups 
+            and 887 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 356 itergroups 
+            and 1104 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 304 itergroups 
+            and 683 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 376 itergroups 
+            and 928 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:Have 169 itergroups 
+            and 684 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 532 itergroups 
+            and 1018 affiliation ids 
+INFO:root:Have 429 itergroups 
+            and 938 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 885 itergroups 
+            and 1153 affiliation ids 
+INFO:root:Have 91 itergroups 
+            and 920 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 370 itergroups 
+            and 748 affiliation ids 
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 26 itergroups 
+            and 641 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 167 itergroups 
+            and 633 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:Have 871 itergroups 
+            and 1085 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 120 itergroups 
+            and 688 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 183 itergroups 
+            and 835 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 25 itergroups 
+            and 668 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 188 itergroups 
+            and 1001 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 862 itergroups 
+            and 1117 affiliation ids 
+INFO:root:Have 612 itergroups 
+            and 968 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 378 itergroups 
+            and 889 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:Have 296 itergroups 
+            and 688 affiliation ids 
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to faculty
+INFO:root:Have 343 itergroups 
+            and 1104 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 193 itergroups 
+            and 691 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 466 itergroups 
+            and 949 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 379 itergroups 
+            and 935 affiliation ids 
+INFO:root:Have 520 itergroups 
+            and 1019 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 874 itergroups 
+            and 1154 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 74 itergroups 
+            and 919 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 359 itergroups 
+            and 761 affiliation ids 
+INFO:root:Have 878 itergroups 
+            and 1087 affiliation ids 
+INFO:root:Have 31 itergroups 
+            and 635 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 221 itergroups 
+            and 824 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 159 itergroups 
+            and 613 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:Have 113 itergroups 
+            and 671 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:Have 20 itergroups 
+            and 666 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:making d_similarity_institutions
+INFO:root:similarity to closest collaborator
+INFO:root:getting student data
+INFO:root:similarity to faculty
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 176 itergroups 
+            and 990 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 889 itergroups 
+            and 1136 affiliation ids 
+INFO:root:similarity to closest collaborator
+INFO:root:similarity to closest collaborator
+INFO:root:Have 612 itergroups 
+            and 955 affiliation ids 
+INFO:root:Have 387 itergroups 
+            and 880 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:Have 302 itergroups 
+            and 678 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 354 itergroups 
+            and 1106 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 182 itergroups 
+            and 671 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 411 itergroups 
+            and 927 affiliation ids 
+INFO:root:Have 882 itergroups 
+            and 1145 affiliation ids 
+INFO:root:Have 586 itergroups 
+            and 1015 affiliation ids 
+INFO:root:Have 428 itergroups 
+            and 926 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:Have 90 itergroups 
+            and 911 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:Have 866 itergroups 
+            and 1085 affiliation ids 
+INFO:root:Have 359 itergroups 
+            and 746 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:making d_similarity_institutions
+INFO:root:Have 891 itergroups 
+            and 1135 affiliation ids 
+INFO:root:making d_similarity_institutions
+INFO:root:Have 870 itergroups 
+            and 1129 affiliation ids 
+INFO:root:making d_similarity_institutions
+--queries finished.
+Done in 1130.5763326883316 minutes.


### PR DESCRIPTION
compute cosine similarity between
- topics as a student and as a publishing researcher
- topics as a student/researcher and set of employers (carnegie institutions)
   - similarity to average faculty (sum of topics across all faculty members)
   - similarity to closest collaborator

Extend other functions
- enumerated_inputs: move to src/dataprep/helpers/functions.py; add option for limiting the number of elements yielded.